### PR TITLE
refactor: Rseed as Fq

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -48,7 +48,7 @@ jobs:
   # Run our bespoke tooling for codegen, consuming the protocol buffer definitions
   # and emitting generated code. Afterward, there should be no uncommitted changes.
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 jobs:
   penumbra:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -10,7 +10,7 @@ jobs:
     # We use a custom script to generate the index page for https://rustdoc.penumbra.zone,
     # and refactors to rust deps can break that generation. Let's ensure this script exits 0
     # on PRs, but we'll still only deploy after merge into main.
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,7 +38,7 @@ jobs:
   # In particular, links are checked within the docs.
   mdbook:
     # Downgrading runner size to 4vcpu, since we're not compiling code.
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -13,7 +13,7 @@ jobs:
   # and only runs post-merge on main, so 10m isn't bad.
   build:
     timeout-minutes: 30
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,7 +58,7 @@ jobs:
   # As of 2025Q1, the "features" job is the slowest in the CI suite.
   # Consider moving to a scheduled job on main, rather than running on PRs.
   features:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,7 +86,7 @@ jobs:
         run: nix develop --command ./deployments/scripts/check-wasm-compat.sh
 
   test:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,7 +40,7 @@ jobs:
         run: nix develop --command just smoke
 
   pmonitor:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,7 +66,7 @@ jobs:
   # Temporarily disabling these in CI, as the testnet endpoints are
   # incompatible with `main`, given GH5010.
   # testnet:
-  #   runs-on: buildjet-16vcpu-ubuntu-2204
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v4
   #       with:

--- a/crates/bench/benches/nullifier_derivation.rs
+++ b/crates/bench/benches/nullifier_derivation.rs
@@ -38,7 +38,7 @@ fn nullifier_derivation_proving_time(c: &mut Criterion) {
     let note = Note::from_parts(
         address,
         Value::from_str("1upenumbra").expect("valid value"),
-        Rseed([1u8; 32]),
+        Rseed::from([1u8; 32]),
     )
     .expect("can make a note");
     let nullifier = Nullifier(Fq::from(1u64));

--- a/crates/bench/benches/output.rs
+++ b/crates/bench/benches/output.rs
@@ -35,7 +35,8 @@ fn output_proving_time(c: &mut Criterion) {
     .expect("generated 1 address");
     let value_to_send = Value::from_str("1upenumbra").expect("valid value");
 
-    let note = Note::from_parts(address, value_to_send, Rseed([1u8; 32])).expect("can make a note");
+    let note =
+        Note::from_parts(address, value_to_send, Rseed::from([1u8; 32])).expect("can make a note");
     let balance_blinding = Fr::from(1u32);
     let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
     let note_commitment = note.commit();

--- a/crates/core/component/dex/src/swap/plaintext.rs
+++ b/crates/core/component/dex/src/swap/plaintext.rs
@@ -57,8 +57,8 @@ impl SwapPlaintext {
         let rseed_1_hash = hash_1(&OUTPUT_1_BLINDING_DOMAIN_SEPARATOR, fq_rseed);
         let rseed_2_hash = hash_1(&OUTPUT_2_BLINDING_DOMAIN_SEPARATOR, fq_rseed);
         (
-            Rseed(rseed_1_hash.to_bytes()),
-            Rseed(rseed_2_hash.to_bytes()),
+            Rseed::from(rseed_1_hash.to_bytes()),
+            Rseed::from(rseed_2_hash.to_bytes()),
         )
     }
 
@@ -317,7 +317,7 @@ impl TryFrom<pb::SwapPlaintext> for SwapPlaintext {
                 .trading_pair
                 .ok_or_else(|| anyhow::anyhow!("missing trading pair in SwapPlaintext"))?
                 .try_into()?,
-            rseed: Rseed(plaintext.rseed.as_slice().try_into()?),
+            rseed: Rseed::from(plaintext.rseed.as_slice()),
         })
     }
 }
@@ -401,7 +401,7 @@ impl TryFrom<&[u8]> for SwapPlaintext {
                 asset_id: asset::Id::try_from(fee_asset_id_bytes)?,
             }),
             claim_address: pb_address.try_into()?,
-            rseed: Rseed(rseed),
+            rseed: Rseed::from(rseed),
         })
     }
 }

--- a/crates/core/component/dex/src/swap/proof.rs
+++ b/crates/core/component/dex/src/swap/proof.rs
@@ -174,7 +174,7 @@ impl DummyWitness for SwapCircuit {
                     .id(),
             }),
             claim_address: address,
-            rseed: Rseed([1u8; 32]),
+            rseed: Rseed::from([1u8; 32]),
         };
 
         Self {
@@ -320,7 +320,7 @@ mod tests {
             let delta_2_i = Amount::from(0u64);
             let fee = Fee::default();
 
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
             let swap_plaintext = SwapPlaintext {
                 trading_pair,
                 delta_1_i,
@@ -382,7 +382,7 @@ mod tests {
             let delta_2_i = Amount::from(0u64);
             let fee = Fee::default();
 
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
             let swap_plaintext = SwapPlaintext {
                 trading_pair,
                 delta_1_i,

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -336,7 +336,7 @@ impl DummyWitness for SwapClaimCircuit {
                     .id(),
             }),
             claim_address: address,
-            rseed: Rseed([1u8; 32]),
+            rseed: Rseed::from([1u8; 32]),
         };
         let mut sct = tct::Tree::new();
         let swap_commitment = swap_plaintext.swap_commitment();
@@ -611,7 +611,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,
@@ -743,7 +743,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,
@@ -834,7 +834,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -256,7 +256,7 @@ impl DummyWitness for DelegatorVoteCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1u64);
@@ -459,7 +459,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -472,7 +472,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("can insert note commitment into SCT");
             }
@@ -484,7 +484,7 @@ mod tests {
             // All proposals should have a position commitment index of zero, so we need to end the epoch
             // and get the position that corresponds to the first commitment in the new epoch.
             sct.end_epoch().expect("should be able to end an epoch");
-            let first_note_commitment = Note::from_parts(sender.clone(), value_to_send, Rseed([u8::MAX; 32])).expect("can create note").commit();
+            let first_note_commitment = Note::from_parts(sender.clone(), value_to_send, Rseed::from([u8::MAX; 32])).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, first_note_commitment).expect("can insert note commitment into SCT");
             let start_position = sct.witness(first_note_commitment).expect("can witness note commitment").position();
 
@@ -535,7 +535,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -548,7 +548,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("can insert note commitment into SCT");
             }
@@ -557,7 +557,7 @@ mod tests {
             let anchor = sct.root();
             let state_commitment_proof = sct.witness(note_commitment).expect("can witness note commitment");
 
-            let rseed = Rseed([num_commitments as u8; 32]);
+            let rseed = Rseed::from([num_commitments as u8; 32]);
             let not_first_note_commitment = Note::from_parts(sender, value_to_send, rseed).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, not_first_note_commitment).expect("can insert note commitment into SCT");
             // All proposals should have a position commitment index of zero, but this one will not, so

--- a/crates/core/component/shielded-pool/src/backref.rs
+++ b/crates/core/component/shielded-pool/src/backref.rs
@@ -156,7 +156,7 @@ mod tests {
                     .unwrap()
                     .id(),
             };
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
 
             let note = Note::from_parts(sender, value_to_send, rseed).expect("valid note");
             let note_commitment: penumbra_sdk_tct::StateCommitment = note.commit();
@@ -195,7 +195,7 @@ mod tests {
                     .unwrap()
                     .id(),
             };
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
 
             let note = Note::from_parts(sender, value_to_send, rseed).expect("valid note");
             let note_commitment: penumbra_sdk_tct::StateCommitment = note.commit();

--- a/crates/core/component/shielded-pool/src/component/note_manager.rs
+++ b/crates/core/component/shielded-pool/src/component/note_manager.rs
@@ -52,7 +52,7 @@ pub trait NoteManager: StateWrite {
             .as_bytes()[0..32]
             .try_into()?;
 
-        let note = Note::from_parts(address.clone(), value, Rseed(rseed_bytes))?;
+        let note = Note::from_parts(address.clone(), value, Rseed::from(rseed_bytes))?;
         self.add_note_payload(note.payload(), source).await;
 
         Ok(())

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -149,7 +149,7 @@ impl Note {
                     .ok_or_else(|| anyhow::anyhow!("invalid denomination"))?
                     .id(),
             },
-            Rseed([0u8; 32]),
+            Rseed::from([0u8; 32]),
         )
         .map_err(Into::into)
     }
@@ -433,7 +433,7 @@ impl TryFrom<pb::Note> for Note {
             .value
             .ok_or_else(|| anyhow::anyhow!("missing value"))?
             .try_into()?;
-        let rseed = Rseed(msg.rseed.as_slice().try_into()?);
+        let rseed = Rseed::from(msg.rseed.as_slice());
 
         Ok(Note::from_parts(address, value, rseed)?)
     }
@@ -470,7 +470,7 @@ impl TryFrom<pb::NoteView> for NoteView {
             .value
             .ok_or_else(|| anyhow::anyhow!("missing value"))?
             .try_into()?;
-        let rseed = Rseed(msg.rseed.as_slice().try_into()?);
+        let rseed = Rseed::from(msg.rseed.as_slice());
 
         Ok(NoteView {
             address,
@@ -537,7 +537,7 @@ impl TryFrom<&[u8]> for Note {
                         .map_err(|_| Error::NoteDeserializationError)?,
                 ),
             },
-            Rseed(rseed_bytes),
+            Rseed::from(rseed_bytes),
         )
     }
 }

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -119,7 +119,7 @@ impl DummyWitness for NullifierDerivationCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let nullifier = Nullifier(Fq::from(1u64));
@@ -256,7 +256,7 @@ mod tests {
                     amount: Amount::from(amount),
                     asset_id: asset::Id(Fq::from(asset_id64)),
                 },
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let nullifier = Nullifier::derive(&nk, position.into(), &note.commit());
             let public = NullifierDerivationProofPublic {
@@ -290,7 +290,7 @@ mod tests {
                     amount: Amount::from(amount),
                     asset_id: asset::Id(Fq::from(asset_id64)),
                 },
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let nullifier = Nullifier::derive(&nk, position.into(), &note.commit());
 

--- a/crates/core/component/shielded-pool/src/output/plan.rs
+++ b/crates/core/component/shielded-pool/src/output/plan.rs
@@ -161,7 +161,7 @@ impl TryFrom<pb::OutputPlan> for OutputPlan {
                 .dest_address
                 .ok_or_else(|| anyhow::anyhow!("missing address"))?
                 .try_into()?,
-            rseed: Rseed(msg.rseed.as_slice().try_into()?),
+            rseed: Rseed::from(msg.rseed.as_slice()),
             value_blinding: Fr::from_bytes_checked(msg.value_blinding.as_slice().try_into()?)
                 .expect("value_blinding malformed"),
             proof_blinding_r: Fq::from_bytes_checked(msg.proof_blinding_r.as_slice().try_into()?)

--- a/crates/core/component/shielded-pool/src/output/proof.rs
+++ b/crates/core/component/shielded-pool/src/output/proof.rs
@@ -150,7 +150,7 @@ impl DummyWitness for OutputCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let balance_blinding = Fr::from(1u64);
@@ -298,7 +298,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
@@ -335,7 +335,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
 
@@ -380,7 +380,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
 

--- a/crates/core/component/shielded-pool/src/rseed.rs
+++ b/crates/core/component/shielded-pool/src/rseed.rs
@@ -1,12 +1,16 @@
 use decaf377::{Fq, Fr};
 use decaf377_ka as ka;
+use once_cell::sync::Lazy;
 use penumbra_sdk_keys::prf;
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
+pub static RCM_DOMAIN_SEP: Lazy<Fq> =
+    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.rcm"));
+
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Rseed(pub [u8; 32]);
+pub struct Rseed(pub Fq);
 
 impl Rseed {
     /// Generate a new rseed from a random source.
@@ -14,22 +18,39 @@ impl Rseed {
     pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
-        Self(bytes)
+        Self::from(bytes)
     }
 
     /// Derive the ephemeral secret key from the rseed.
     pub fn derive_esk(&self) -> ka::Secret {
-        let hash_result = prf::expand(b"Penumbra_DeriEsk", &self.0, &[4u8]);
+        let hash_result = prf::expand(b"Penumbra_DeriEsk", &self.0.to_bytes(), &[4u8]);
         ka::Secret::new_from_field(Fr::from_le_bytes_mod_order(hash_result.as_bytes()))
     }
 
     /// Derive note commitment randomness from the rseed.
     pub fn derive_note_blinding(&self) -> Fq {
-        let hash_result = prf::expand(b"Penumbra_DeriRcm", &self.0, &[5u8]);
-        Fq::from_le_bytes_mod_order(hash_result.as_bytes())
+        poseidon377::hash_1(&RCM_DOMAIN_SEP, self.0)
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
+        self.0.to_bytes()
+    }
+}
+
+impl From<[u8; 32]> for Rseed {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(&bytes))
+    }
+}
+
+impl From<&[u8; 32]> for Rseed {
+    fn from(bytes: &[u8; 32]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(bytes))
+    }
+}
+
+impl From<&[u8]> for Rseed {
+    fn from(bytes: &[u8]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(bytes))
     }
 }

--- a/crates/core/component/shielded-pool/src/rseed.rs
+++ b/crates/core/component/shielded-pool/src/rseed.rs
@@ -6,7 +6,7 @@ use penumbra_sdk_keys::prf;
 use rand::{CryptoRng, RngCore};
 
 pub static RCM_DOMAIN_SEP: Lazy<Fq> =
-    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.rcm"));
+    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.pool.rcm"));
 
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -231,7 +231,7 @@ impl DummyWitness for SpendCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1u64);
@@ -423,7 +423,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -436,7 +436,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -492,7 +492,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -505,7 +505,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -577,7 +577,7 @@ mod tests {
             let note = Note::from_parts(
                 wrong_sender,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -635,7 +635,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -648,12 +648,12 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
             // Insert one more note commitment and witness it.
-            let rseed = Rseed([num_commitments as u8; 32]);
+            let rseed = Rseed::from([num_commitments as u8; 32]);
             let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             let incorrect_position = sct.witness(dummy_note_commitment).expect("can witness note commitment").position();
@@ -709,7 +709,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -722,7 +722,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -778,7 +778,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let nk = *sk_sender.nullifier_key();
@@ -790,7 +790,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -847,7 +847,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -956,7 +956,7 @@ mod tests {
             let note = Note::from_parts(
                 address,
                 Value::from_str("1upenumbra").expect("valid value"),
-                Rseed([1u8; 32]),
+                Rseed::from([1u8; 32]),
             )
             .expect("can make a note");
             let mut sct = tct::Tree::new();
@@ -986,7 +986,7 @@ mod tests {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         note.commit()

--- a/crates/core/transaction/tests/generate_transaction_signing_test_vectors.rs
+++ b/crates/core/transaction/tests/generate_transaction_signing_test_vectors.rs
@@ -385,7 +385,7 @@ fn note_strategy_without_address() -> impl Strategy<Value = Note> {
         prop::array::uniform32(any::<u8>()),
     )
         .prop_map(|(address, value, rseed_bytes)| {
-            Note::from_parts(address, value, Rseed(rseed_bytes))
+            Note::from_parts(address, value, Rseed::from(rseed_bytes))
                 .expect("should be a valid test note")
         })
 }

--- a/crates/view/src/note_record.rs
+++ b/crates/view/src/note_record.rs
@@ -108,7 +108,7 @@ impl TryFrom<&Row<'_>> for SpendableNoteRecord {
                     amount: u128::from_be_bytes(row.get::<_, [u8; 16]>("amount")?).into(),
                     asset_id: row.get::<_, Vec<u8>>("asset_id")?[..].try_into()?,
                 },
-                Rseed(row.get::<_, [u8; 32]>("rseed")?),
+                Rseed::from(row.get::<_, [u8; 32]>("rseed")?),
             )?,
             source: CommitmentSource::decode(&row.get::<_, Vec<u8>>("source")?[..])?,
             return_address,

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -1346,7 +1346,7 @@ impl Storage {
                     let amount = row.get::<_, [u8; 16]>("amount")?;
                     let amount_u128: u128 = u128::from_be_bytes(amount);
                     let asset_id = asset::Id(Fq::from_bytes_checked(&row.get::<_, [u8; 32]>("asset_id")?).expect("asset id malformed"));
-                    let rseed = Rseed(row.get::<_, [u8; 32]>("rseed")?);
+                    let rseed = Rseed::from(row.get::<_, [u8; 32]>("rseed")?);
                     let note = Note::from_parts(
                         address,
                         Value {


### PR DESCRIPTION
## Describe your changes

Changes Rseed to wrap an `Fq` rather than `[u8; 32]`, and changes rcm derivation to use Poseidon

<!--
Describe what's changed and why. If interactive testing is required, explain
to the reviewer how the PR should be tested.
-->

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
