### PR TITLE
adjust rcm domain separator

### DIFF
--- a/crates/core/component/shielded-pool/src/rseed.rs
+++ b/crates/core/component/shielded-pool/src/rseed.rs
@@ -6,7 +6,7 @@ use penumbra_sdk_keys::prf;
 use rand::{CryptoRng, RngCore};
 
 pub static RCM_DOMAIN_SEP: Lazy<Fq> =
-    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.pool.rcm"));
+    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.rcm"));
 
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Describe your changes

Adjusting the RCM domain separator to be the same between Cycles `Rseed`s and Penumbra
<!--
Describe what's changed and why. If interactive testing is required, explain
to the reviewer how the PR should be tested.
-->

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
