### PR TITLE
fix: gate r1cs for shielded pool

### DIFF
--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -18,16 +18,15 @@ component = [
     "ibc-proto/server",
     "ibc-proto/transport",
 ]
-# proving-keys = ["penumbra-sdk-proof-params/proving-keys"]
-default = ["std", "component", "rand", "decaf377/arkworks", "penumbra-sdk-proto/tendermint"]
+default = ["std", "component", "rand", "r1cs", "decaf377/arkworks", "penumbra-sdk-proto/tendermint"]
 std = ["ark-ff/std"]
 parallel = [
     "penumbra-sdk-tct/parallel",
     "ark-ff/parallel",
     "poseidon377/parallel",
     "decaf377-rdsa/parallel",
-    "ark-groth16/parallel",
-    "ark-r1cs-std/parallel",
+    "ark-groth16?/parallel",
+    "ark-r1cs-std?/parallel",
     "decaf377/parallel",
     "tonic",
 ]
@@ -46,15 +45,23 @@ rand = [
     "penumbra-sdk-tct/rand",
     "penumbra-sdk-proof-params/rand",
 ]
+r1cs = [
+    "dep:ark-groth16",
+    "dep:ark-r1cs-std",
+    "dep:ark-relations",
+    "dep:ark-snark",
+    "decaf377/r1cs",
+    "poseidon377/r1cs",
+]
 
 [dependencies]
 anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
-ark-groth16 = {workspace = true, default-features = false}
-ark-r1cs-std = {workspace = true, default-features = false}
-ark-relations = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false, optional = true}
+ark-r1cs-std = {workspace = true, default-features = false, optional = true}
+ark-relations = {workspace = true, optional = true}
 ark-serialize = {workspace = true}
-ark-snark = {workspace = true}
+ark-snark = {workspace = true, optional = true}
 async-stream = {workspace = true}
 async-trait = {workspace = true}
 base64 = {workspace = true}
@@ -63,7 +70,7 @@ bytes = {workspace = true}
 chacha20poly1305 = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = false}
+decaf377 = {workspace = true, default-features = false}
 decaf377-fmd = {workspace = true, default-features = false}
 decaf377-ka = {workspace = true, default-features = false}
 decaf377-rdsa = {workspace = true, default-features = false}
@@ -83,7 +90,7 @@ penumbra-sdk-proto = {workspace = true, default-features = false}
 penumbra-sdk-sct = {workspace = true, default-features = false}
 penumbra-sdk-tct = {workspace = true, default-features = false}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
-poseidon377 = {workspace = true, features = ["r1cs"], default-features = false}
+poseidon377 = {workspace = true, default-features = false}
 prost = {workspace = true}
 rand = {workspace = true, optional = true}
 rand_core = {workspace = true, features = ["getrandom"], optional = true}

--- a/crates/core/component/shielded-pool/src/lib.rs
+++ b/crates/core/component/shielded-pool/src/lib.rs
@@ -20,20 +20,29 @@ pub use note::{Note, NoteCiphertext, NoteView};
 pub use note_payload::NotePayload;
 pub use rseed::Rseed;
 
-pub mod convert;
-pub mod nullifier_derivation;
-pub mod output;
-pub mod spend;
-
 pub mod backref;
 pub use backref::{Backref, EncryptedBackref};
 
+#[cfg(feature = "r1cs")]
+pub mod convert;
+#[cfg(feature = "r1cs")]
+pub mod nullifier_derivation;
+#[cfg(feature = "r1cs")]
+pub mod output;
+#[cfg(feature = "r1cs")]
+pub mod spend;
+
+#[cfg(feature = "r1cs")]
 pub use convert::{ConvertCircuit, ConvertProof, ConvertProofPrivate, ConvertProofPublic};
+#[cfg(feature = "r1cs")]
 pub use nullifier_derivation::{
     NullifierDerivationCircuit, NullifierDerivationProof, NullifierDerivationProofPrivate,
     NullifierDerivationProofPublic,
 };
+#[cfg(feature = "r1cs")]
 pub use output::{Output, OutputCircuit, OutputPlan, OutputProof, OutputView};
+#[cfg(feature = "r1cs")]
 pub use spend::{
     Spend, SpendCircuit, SpendPlan, SpendProof, SpendProofPrivate, SpendProofPublic, SpendView,
 };
+

--- a/crates/core/component/shielded-pool/src/lib.rs
+++ b/crates/core/component/shielded-pool/src/lib.rs
@@ -45,4 +45,3 @@ pub use output::{Output, OutputCircuit, OutputPlan, OutputProof, OutputView};
 pub use spend::{
     Spend, SpendCircuit, SpendPlan, SpendProof, SpendProofPrivate, SpendProofPublic, SpendView,
 };
-

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -17,7 +17,9 @@ use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use thiserror;
 
+#[cfg(feature = "r1cs")]
 mod r1cs;
+#[cfg(feature = "r1cs")]
 pub use r1cs::NoteVar;
 
 pub use penumbra_sdk_tct::StateCommitment;

--- a/crates/core/keys/src/keys/ivk.rs
+++ b/crates/core/keys/src/keys/ivk.rs
@@ -206,6 +206,7 @@ mod test {
         test_keys,
     };
     use proptest::prelude::*;
+    use rand::rngs;
     use std::str::FromStr;
 
     use super::*;

--- a/crates/core/keys/src/keys/ivk.rs
+++ b/crates/core/keys/src/keys/ivk.rs
@@ -206,7 +206,6 @@ mod test {
         test_keys,
     };
     use proptest::prelude::*;
-    use rand::rngs;
     use std::str::FromStr;
 
     use super::*;


### PR DESCRIPTION
## Summary
<!--
Describe what's changed and why. If interactive testing is required, explain
to the reviewer how the PR should be tested.
-->

Moves `r1cs` dependencies in `penumbra-sdk-shielded-pool` under a feature gate. This makes `penumbra-sdk-shielded-pool` possible to compile to the `wasm32-unknown-unknown` target

