### PR TITLE
fix: wasm-bindgen problem

### DIFF
--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -93,7 +93,7 @@ penumbra-sdk-txhash = {workspace = true, default-features = false}
 poseidon377 = {workspace = true, default-features = false}
 prost = {workspace = true}
 rand = {workspace = true, optional = true}
-rand_core = {workspace = true, features = ["getrandom"], optional = true}
+rand_core = {workspace = true, optional = true}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
@@ -105,3 +105,4 @@ tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}

--- a/crates/crypto/decaf377-fmd/Cargo.toml
+++ b/crates/crypto/decaf377-fmd/Cargo.toml
@@ -13,18 +13,23 @@ harness = false
 
 
 [features]
-default = ["rand", "decaf377/arkworks"]
+default = ["rand", "ark-ff", "ark-serialize"]
 rand = ["decaf377/rand", "rand_core"]
+arkworks = ["decaf377/arkworks"]
 
 [dependencies]
-ark-ff = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
+ark-ff = {workspace = true, default-features = false, optional = true}
+ark-serialize = {workspace = true, optional = true}
 bitvec = {workspace = true}
 blake2b_simd = {workspace = true}
-decaf377 = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"], optional = true}
+decaf377 = {workspace = true, default-features = false}
+rand_core = {workspace = true, optional = true}
 thiserror = {workspace = true}
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rand_core = {workspace = true, optional = true}
 
 [dev-dependencies]
 criterion = {workspace = true, features = ["html_reports"]}
 proptest = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}

--- a/crates/crypto/decaf377-ka/Cargo.toml
+++ b/crates/crypto/decaf377-ka/Cargo.toml
@@ -16,7 +16,7 @@ rand = ["decaf377/rand", "rand_core"]
 ark-ff = {workspace = true, default-features = false}
 decaf377 = {workspace = true}
 hex = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"], optional = true}
+rand_core = {workspace = true, optional = true}
 thiserror = {workspace = true}
 zeroize = "1.4"
 zeroize_derive = "1.3"

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -8,7 +8,7 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
-default = ["rand", "decaf377/arkworks"]
+default = ["rand", "decaf377/arkworks", "getrandom-js"]
 internal = []
 arbitrary = ["proptest", "proptest-derive"]
 r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs", "poseidon377/r1cs"]
@@ -17,6 +17,8 @@ rand = [
     "dep:rand",
     "decaf377/rand",
 ]
+# Enable wasm-bindgen integration for browser-based WASM (not CosmWasm)
+getrandom-js = ["dep:getrandom"]
 
 [dependencies]
 ark-ed-on-bls12-377 = "0.4"
@@ -29,7 +31,7 @@ blake2b_simd = {workspace = true}
 decaf377 = {workspace = true}
 derivative = {workspace = true}
 futures = {workspace = true}
-getrandom = {workspace = true, features = ["js"]}
+getrandom = {workspace = true, features = ["js"], optional = true}
 hash_hasher = "2"
 hex = {workspace = true}
 im = {workspace = true, features = ["serde"]}


### PR DESCRIPTION
This PR attempts makes changes needed to make the `penumbra-sdk-shielded-pool` package compatible with cw-check. 

The changes have been tested by importing `penumbra-sdk-shielded-pool` into an empty contract, and running cw-check on the contract. 