### PR TITLE
fix: feature gate ibc deps

### DIFF
--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -17,7 +17,10 @@ component = [
     "tonic",
     "ibc-proto/server",
     "ibc-proto/transport",
+    "ibc",
+    "penumbra-sdk-ibc"
 ]
+ibc = ["dep:ibc-types", "penumbra-sdk-ibc"]
 default = ["std", "component", "rand", "r1cs", "decaf377/arkworks", "penumbra-sdk-proto/tendermint"]
 std = ["ark-ff/std"]
 parallel = [
@@ -77,12 +80,12 @@ decaf377-rdsa = {workspace = true, default-features = false}
 futures = {workspace = true}
 hex = {workspace = true}
 ibc-proto = {workspace = true, default-features = false}
-ibc-types = {workspace = true, features = ["with_serde"], default-features = false}
+ibc-types = {workspace = true, features = ["with_serde"], default-features = false, optional = true}
 im = {workspace = true}
 metrics = {workspace = true}
 once_cell = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
-penumbra-sdk-ibc = {workspace = true, default-features = false}
+penumbra-sdk-ibc = {workspace = true, default-features = false, optional = true }
 penumbra-sdk-keys = {workspace = true, default-features = false}
 penumbra-sdk-num = {workspace = true, default-features = false}
 penumbra-sdk-proof-params = {workspace = true, default-features = false}

--- a/crates/core/component/shielded-pool/src/component.rs
+++ b/crates/core/component/shielded-pool/src/component.rs
@@ -3,18 +3,22 @@
 mod action_handler;
 mod assets;
 mod fmd;
+#[cfg(feature = "ibc")]
 mod ics20_withdrawal_with_handler;
 mod metrics;
 mod note_manager;
 mod shielded_pool;
+#[cfg(feature = "ibc")]
 mod transfer;
 
 pub use self::metrics::register_metrics;
 pub use assets::{AssetRegistry, AssetRegistryRead};
 pub use fmd::ClueManager;
+#[cfg(feature = "ibc")]
 pub use ics20_withdrawal_with_handler::Ics20WithdrawalWithHandler;
 pub use note_manager::NoteManager;
 pub use shielded_pool::{ShieldedPool, StateReadExt, StateWriteExt};
+#[cfg(feature = "ibc")]
 pub use transfer::Ics20Transfer;
 
 pub mod rpc;

--- a/crates/core/component/shielded-pool/src/lib.rs
+++ b/crates/core/component/shielded-pool/src/lib.rs
@@ -3,7 +3,9 @@
 #[cfg(feature = "component")]
 pub mod component;
 
+#[cfg(feature = "ibc")]
 pub mod ics20_withdrawal;
+#[cfg(feature = "ibc")]
 pub use ics20_withdrawal::Ics20Withdrawal;
 
 pub mod event;


### PR DESCRIPTION
This PR supersedes #6 as a better solution to the problem with `penumbra-sdk-shielded-pool` causing our cosmwasm contract to fail `cw-check`. 

In summary, the problem we faced was that `penumbra-sdk-shielded-pool` was bringing in `rand` as a dependency with the `std` feature enabled. This in turn brings in `getrandom` and `wasm-bindgen`, which requires a custom implementation to work in a cosmwasm environment. The `js` feature meant that the wasm binary was compiling, but failing `cw-check` because there wasn't an actual JavaScript runtime to call into. 

The confusion came from the fact that `getrandom` and `wasm-bindgen` was *already* a dependency in our contract via `tct`, but was not causing problems until `penumbra-sdk-shielded-pool` was added as a dependency, even though randomness wasn't being used in the contract. 

The reason for this was due to cargo's feature unification - there's only one copy of each dependency in the final build, compiled with the union of all features requested from dependents. So before `penumbra-sdk-shielded-pool`, `rand_core` still existed, but without the `getrandom` feature enabled. `getrandom` with `js` also still existed from the `tct` package, but since there were no live code paths using it, the compiler was able to discard it.

Once `penumbra-sdk-shielded-pool` came in, `rand_core` now compiled with `getrandom`, which forced that package to end up on a bunch of live paths. The compiler would no longer be able to strip it away during compilation, leaving us with a wasm file which has `wasm-bindgen` calls into non-existent JavaScript. 

Pr #6 attempted to fix this by removing the `js` feature from `tct`'s `getrandom` dependency. This would allow us to write a custom `getrandom` bindgen impl to be used in our contract. An upstream change was necessary because the `js` feature would override a local custom implementation when I wrote one in the contract.

This PR fixes the underlying problem by making the dependency from `shielded-pool` which enabled `rand` and its `std` flag *optional*, so that the contract can compile without it. This is better than #6 since it removes the need to write an unused custom `getrandom` handler in our contract, and reduces bloat/complexity in our dependencies. 

This change was tested by writing a dummy contract which uses our local `cycles-core` contract along with the local `shielded-pool` package to see if the resulting contract passes `cw-check`. The test passed, and enabling the new "ibc" feature causes the test to fail.