### PR TITLE
add missing serialization support

### DIFF
--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -11,10 +11,10 @@ edition = {workspace = true}
 anyhow             = { workspace = true }
 ark-ff             = { workspace = true, default-features = false }
 blake2b_simd       = { workspace = true }
-decaf377           = { workspace = true }
-decaf377-rdsa      = {workspace = true}
-frost-core         = "0.7"
-frost-rerandomized = "0.7"
+decaf377           = { workspace = true, features = ["arkworks", "rand"]}
+decaf377-rdsa      = { workspace = true}
+frost-core         = "1.0.0"
+frost-rerandomized = "1.0.0"
 rand_core          = { workspace = true, features = ["getrandom"] }
 penumbra-sdk-proto = { workspace = true, default-features = true }
 getrandom          = { workspace = true, features = ["js"] }

--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -8,12 +8,16 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [dependencies]
-anyhow = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-blake2b_simd = {workspace = true}
-decaf377 = {workspace = true}
-decaf377-rdsa = {workspace = true}
-frost-core = "0.7"
+anyhow             = { workspace = true }
+ark-ff             = { workspace = true, default-features = false }
+blake2b_simd       = { workspace = true }
+decaf377           = { workspace = true }
+decaf377-rdsa      = {workspace = true}
+frost-core         = "0.7"
 frost-rerandomized = "0.7"
-rand_core = {workspace = true, features = ["getrandom"]}
-penumbra-sdk-proto = {workspace = true, default-features = true}
+rand_core          = { workspace = true, features = ["getrandom"] }
+penumbra-sdk-proto = { workspace = true, default-features = true }
+getrandom          = { workspace = true, features = ["js"] }
+# serialization
+serde              = { workspace = true, features = ["derive"] }
+hex                = { workspace = true }

--- a/crates/crypto/decaf377-frost/src/keys.rs
+++ b/crates/crypto/decaf377-frost/src/keys.rs
@@ -2,7 +2,7 @@
 
 use decaf377_rdsa::{SigningKey, SpendAuth};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use rand_core::RngCore;
 
@@ -20,7 +20,7 @@ pub fn generate_with_dealer<RNG: RngCore + CryptoRng>(
     min_signers: u16,
     identifiers: IdentifierList,
     mut rng: RNG,
-) -> Result<(HashMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
+) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     frost::keys::generate_with_dealer(max_signers, min_signers, identifiers, &mut rng)
 }
 
@@ -36,7 +36,7 @@ pub fn split<R: RngCore + CryptoRng>(
     min_signers: u16,
     identifiers: IdentifierList,
     rng: &mut R,
-) -> Result<(HashMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
+) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     // https://github.com/ZcashFoundation/frost/issues/497
     let frost_secret = frost_core::SigningKey::deserialize(secret.to_bytes().to_vec())?;
     frost::keys::split(&frost_secret, max_signers, min_signers, identifiers, rng)

--- a/crates/crypto/decaf377-frost/src/keys/dkg.rs
+++ b/crates/crypto/decaf377-frost/src/keys/dkg.rs
@@ -91,7 +91,7 @@ pub mod round2 {
         fn from(value: Package) -> Self {
             Self {
                 signing_share: Some(pb::SigningShare {
-                    scalar: value.0.secret_share().serialize(),
+                    scalar: value.0.signing_share().serialize(),
                 }),
             }
         }

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -39,8 +39,6 @@ pub mod round1 {
 
     use super::*;
 
-    // pub type SigningNonces = frost::round1::SigningNonces<E>;
-
     /// The nonces used for a single FROST signing ceremony.
     /// Published by each participant in the first round of the signing protocol.
     ///
@@ -86,6 +84,52 @@ pub mod round1 {
 
     impl DomainType for SigningNonces {
         type Proto = pb::SigningNonces;
+    }
+
+    impl SigningNonces {
+        /// Serialize to 64 bytes (hiding || binding)
+        pub fn to_bytes(&self) -> [u8; 64] {
+            let mut bytes = [0u8; 64];
+            bytes[..32].copy_from_slice(&self.0.hiding().serialize());
+            bytes[32..].copy_from_slice(&self.0.binding().serialize());
+            bytes
+        }
+    
+        /// Deserialize from 64 bytes
+        pub fn from_bytes(bytes: &[u8; 64]) -> Result<Self, Error> {
+            let hiding = frost::round1::Nonce::deserialize(bytes[..32].to_vec())?;
+            let binding = frost::round1::Nonce::deserialize(bytes[32..].to_vec())?;
+            Ok(Self(frost::round1::SigningNonces::from_nonces(hiding, binding)))
+        }
+    }
+
+    impl Serialize for SigningNonces {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let bytes = self.to_bytes();
+            if serializer.is_human_readable() {
+                hex::encode(&bytes).serialize(serializer)
+            } else {
+                serializer.serialize_bytes(&bytes)
+            }
+        }
+    }
+    
+    impl<'de> Deserialize<'de> for SigningNonces {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let bytes = if deserializer.is_human_readable() {
+                let hex_str = String::deserialize(deserializer)?;
+                hex::decode(&hex_str).map_err(serde::de::Error::custom)?
+            } else {
+                <Vec<u8>>::deserialize(deserializer)?
+            };
+            Self::from_bytes(bytes.as_slice()).map_err(serde::de::Error::custom)
+        }
     }
 
     /// Published by each participant in the first round of the signing protocol.

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -9,6 +9,7 @@
 use anyhow::anyhow;
 use frost_core::frost;
 use penumbra_sdk_proto::crypto::decaf377_frost::v1 as pb;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
 
 /// A FROST-related error.
@@ -132,6 +133,37 @@ impl SigningPackage {
         self.0
             .signing_commitment(identifier)
             .map(round1::SigningCommitments)
+    }
+}
+
+impl Serialize for SigningPackage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.0.serialize().map_err(serde::ser::Error::custom)?;
+        // Serialize as hex string for human-readable formats
+        if serializer.is_human_readable() {
+            hex::encode(&bytes).serialize(serializer)
+        } else {
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SigningPackage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = if deserializer.is_human_readable() {
+            let hex_str = <String>::deserialize(deserializer)?;
+            hex::decode(&hex_str).map_err(serde::de::Error::custom)?
+        } else {
+            <Vec<u8>>::deserialize(deserializer)?
+        };
+        let inner = frost::SigningPackage::deserialize(&bytes).map_err(serde::de::Error::custom)?;
+        Ok(Self(inner))
     }
 }
 

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use anyhow::anyhow;
-use frost_core::frost;
+use frost_core as frost;
 use penumbra_sdk_proto::crypto::decaf377_frost::v1 as pb;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
@@ -34,18 +34,59 @@ pub type Identifier = frost::Identifier<E>;
 
 /// Signing round 1 functionality and types.
 pub mod round1 {
-    use penumbra_sdk_proto::DomainType;
-
     use crate::keys::SigningShare;
+    use penumbra_sdk_proto::DomainType;
 
     use super::*;
 
+    // pub type SigningNonces = frost::round1::SigningNonces<E>;
+
     /// The nonces used for a single FROST signing ceremony.
+    /// Published by each participant in the first round of the signing protocol.
     ///
     /// Note that [`SigningNonces`] must be used *only once* for a signing
     /// operation; re-using nonces will result in leakage of a signer's long-lived
     /// signing key.
-    pub type SigningNonces = frost::round1::SigningNonces<E>;
+    #[derive(Debug, Clone)]
+    pub struct SigningNonces(pub(crate) frost::round1::SigningNonces<E>);
+
+    impl From<SigningNonces> for pb::SigningNonces {
+        fn from(value: SigningNonces) -> Self {
+            Self {
+                hiding: Some(pb::Nonce {
+                    scalar: value.0.hiding().serialize(),
+                }),
+                binding: Some(pb::Nonce {
+                    scalar: value.0.binding().serialize(),
+                }),
+            }
+        }
+    }
+
+    impl TryFrom<pb::SigningNonces> for SigningNonces {
+        type Error = anyhow::Error;
+
+        fn try_from(value: pb::SigningNonces) -> Result<Self, Self::Error> {
+            Ok(Self(frost::round1::SigningNonces::from_nonces(
+                frost::round1::Nonce::deserialize(
+                    value
+                        .hiding
+                        .ok_or(anyhow!("SigningNonces missing hiding"))?
+                        .scalar,
+                )?,
+                frost::round1::Nonce::deserialize(
+                    value
+                        .binding
+                        .ok_or(anyhow!("SigningNonces missing binding"))?
+                        .scalar,
+                )?,
+            )))
+        }
+    }
+
+    impl DomainType for SigningNonces {
+        type Proto = pb::SigningNonces;
+    }
 
     /// Published by each participant in the first round of the signing protocol.
     ///
@@ -101,7 +142,7 @@ pub mod round1 {
         RNG: CryptoRng + RngCore,
     {
         let (a, b) = frost::round1::commit::<E, RNG>(secret, rng);
-        (a, SigningCommitments(b))
+        (SigningNonces(a), SigningCommitments(b))
     }
 }
 
@@ -214,7 +255,7 @@ pub mod round2 {
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
     ) -> Result<SignatureShare, Error> {
-        frost::round2::sign(&signing_package.0, signer_nonces, key_package).map(SignatureShare)
+        frost::round2::sign(&signing_package.0, &signer_nonces.0, key_package).map(SignatureShare)
     }
 
     /// Like [`sign`], but for producing signatures with a randomized verification key.
@@ -226,7 +267,7 @@ pub mod round2 {
     ) -> Result<SignatureShare, Error> {
         frost_rerandomized::sign(
             &signing_package.0,
-            signer_nonces,
+            &signer_nonces.0,
             key_package,
             Randomizer::from_scalar(randomizer),
         )
@@ -283,7 +324,7 @@ pub fn aggregate_randomized(
         &signature_shares,
         pubkeys,
         &frost_rerandomized::RandomizedParams::from_randomizer(
-            pubkeys.group_public(),
+            pubkeys.verifying_key(),
             frost_rerandomized::Randomizer::from_scalar(randomizer),
         ),
     )?;

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -2,6 +2,7 @@ use ark_ff::{One, Zero};
 use decaf377::{Element, Fr};
 pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
 use rand_core;
+use serde::{Deserialize, Serialize};
 
 use crate::hash::Hasher;
 
@@ -80,7 +81,7 @@ impl Group for Decaf377Group {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub struct Decaf377Rdsa;
 
 #[allow(non_snake_case)]

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -1,6 +1,8 @@
 use ark_ff::{One, Zero};
 use decaf377::{Element, Fr};
+use frost_core::Scalar;
 pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+use frost_rerandomized::RandomizedCiphersuite;
 use rand_core;
 use serde::{Deserialize, Serialize};
 
@@ -123,5 +125,16 @@ impl Ciphersuite for Decaf377Rdsa {
 
     fn HID(m: &[u8]) -> Option<<<Self::Group as Group>::Field as Field>::Scalar> {
         Some(Hasher::default().update(b"id").update(m).finalize_scalar())
+    }
+}
+
+impl RandomizedCiphersuite for Decaf377Rdsa {
+    fn hash_randomizer(m: &[u8]) -> Option<Scalar<Self>> {
+        Some(
+            Hasher::default()
+                .update(b"randomizer")
+                .update(m)
+                .finalize_scalar(),
+        )
     }
 }

--- a/crates/crypto/decaf377-frost/tests/frost.rs
+++ b/crates/crypto/decaf377-frost/tests/frost.rs
@@ -75,7 +75,7 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
     let mut sign_round1_nonces = HashMap::new();
 
     for id in &ids {
-        let (nonce, commitment) = frost::round1::commit(&shares[id].secret_share(), &mut OsRng);
+        let (nonce, commitment) = frost::round1::commit(&shares[id].signing_share(), &mut OsRng);
         signing_commitments.insert(*id, commitment);
         sign_round1_nonces.insert(*id, nonce);
     }
@@ -105,7 +105,7 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
         .values()
         .next()
         .unwrap()
-        .group_public()
+        .verifying_key()
         .serialize()
         .try_into()
         .expect("serialize should not fail");
@@ -120,7 +120,7 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
     let mut sign_round1_nonces = HashMap::new();
 
     for id in &ids {
-        let (nonce, commitment) = frost::round1::commit(&shares[id].secret_share(), &mut OsRng);
+        let (nonce, commitment) = frost::round1::commit(&shares[id].signing_share(), &mut OsRng);
         signing_commitments.insert(*id, commitment);
         sign_round1_nonces.insert(*id, nonce);
     }

--- a/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.rs
+++ b/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.rs
@@ -70,6 +70,43 @@ impl ::prost::Name for DkgRound2Package {
         "/penumbra.crypto.decaf377_frost.v1.DKGRound2Package".into()
     }
 }
+/// A signing nonce, a scalar used once in the signing protocol.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Nonce {
+    /// These bytes should be a valid scalar.
+    #[prost(bytes = "vec", tag = "1")]
+    pub scalar: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for Nonce {
+    const NAME: &'static str = "Nonce";
+    const PACKAGE: &'static str = "penumbra.crypto.decaf377_frost.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "penumbra.crypto.decaf377_frost.v1.Nonce".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/penumbra.crypto.decaf377_frost.v1.Nonce".into()
+    }
+}
+/// The nonces used for a single FROST signing ceremony.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SigningNonces {
+    /// The hiding nonce.
+    #[prost(message, optional, tag = "1")]
+    pub hiding: ::core::option::Option<Nonce>,
+    /// The binding nonce.
+    #[prost(message, optional, tag = "2")]
+    pub binding: ::core::option::Option<Nonce>,
+}
+impl ::prost::Name for SigningNonces {
+    const NAME: &'static str = "SigningNonces";
+    const PACKAGE: &'static str = "penumbra.crypto.decaf377_frost.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "penumbra.crypto.decaf377_frost.v1.SigningNonces".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/penumbra.crypto.decaf377_frost.v1.SigningNonces".into()
+    }
+}
 /// Represents a commitment to a nonce value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NonceCommitment {

--- a/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.serde.rs
+++ b/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.serde.rs
@@ -211,6 +211,105 @@ impl<'de> serde::Deserialize<'de> for DkgRound2Package {
         deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.DKGRound2Package", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for Nonce {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.scalar.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.crypto.decaf377_frost.v1.Nonce", len)?;
+        if !self.scalar.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("scalar", pbjson::private::base64::encode(&self.scalar).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Nonce {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "scalar",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Scalar,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "scalar" => Ok(GeneratedField::Scalar),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Nonce;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.crypto.decaf377_frost.v1.Nonce")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Nonce, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut scalar__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Scalar => {
+                            if scalar__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("scalar"));
+                            }
+                            scalar__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(Nonce {
+                    scalar: scalar__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.Nonce", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for NonceCommitment {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -519,6 +618,118 @@ impl<'de> serde::Deserialize<'de> for SigningCommitments {
             }
         }
         deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.SigningCommitments", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SigningNonces {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.hiding.is_some() {
+            len += 1;
+        }
+        if self.binding.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.crypto.decaf377_frost.v1.SigningNonces", len)?;
+        if let Some(v) = self.hiding.as_ref() {
+            struct_ser.serialize_field("hiding", v)?;
+        }
+        if let Some(v) = self.binding.as_ref() {
+            struct_ser.serialize_field("binding", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SigningNonces {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "hiding",
+            "binding",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Hiding,
+            Binding,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "hiding" => Ok(GeneratedField::Hiding),
+                            "binding" => Ok(GeneratedField::Binding),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SigningNonces;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.crypto.decaf377_frost.v1.SigningNonces")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SigningNonces, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut hiding__ = None;
+                let mut binding__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Hiding => {
+                            if hiding__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hiding"));
+                            }
+                            hiding__ = map_.next_value()?;
+                        }
+                        GeneratedField::Binding => {
+                            if binding__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("binding"));
+                            }
+                            binding__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(SigningNonces {
+                    hiding: hiding__,
+                    binding: binding__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.SigningNonces", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SigningShare {

--- a/proto/penumbra/penumbra/crypto/decaf377_frost/v1/decaf377_frost.proto
+++ b/proto/penumbra/penumbra/crypto/decaf377_frost/v1/decaf377_frost.proto
@@ -28,6 +28,20 @@ message DKGRound2Package {
   SigningShare signing_share = 1;
 }
 
+// A signing nonce, a scalar used once in the signing protocol.
+message Nonce {
+  // These bytes should be a valid scalar.
+  bytes scalar = 1;
+}
+
+// The nonces used for a single FROST signing ceremony.
+message SigningNonces {
+  // The hiding nonce.
+  Nonce hiding = 1;
+  // The binding nonce.
+  Nonce binding = 2;
+}
+
 // Represents a commitment to a nonce value.
 message NonceCommitment {
   // These bytes should be a valid group element.


### PR DESCRIPTION
Adds missing serialization support for:
- SigningNonces
- KeyPackage
- PublicKeyPackage

Bumps frost v0.7.0 to 1.0.0
- this was necessary to enable de/serialization of the SigningNonce type