### PR TITLE
bump frost version to 2.1.0

### DIFF
--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -19,8 +19,8 @@ ark-ff             = { workspace = true, default-features = false }
 blake2b_simd       = { workspace = true }
 decaf377           = { workspace = true, features = ["rand", "arkworks"] }
 decaf377-rdsa      = { workspace = true}
-frost-core         = "1.0.0"
-frost-rerandomized = "1.0.0"
+frost-core         = "2.1.0"
+frost-rerandomized = "2.1.0"
 rand_core          = { workspace = true, features = ["getrandom"] }
 penumbra-sdk-proto = { workspace = true, default-features = true }
 getrandom          = { workspace = true, features = ["js"] }

--- a/crates/crypto/decaf377-frost/src/keys.rs
+++ b/crates/crypto/decaf377-frost/src/keys.rs
@@ -38,7 +38,7 @@ pub fn split<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     // https://github.com/ZcashFoundation/frost/issues/497
-    let frost_secret = frost_core::SigningKey::deserialize(secret.to_bytes().to_vec())?;
+    let frost_secret = frost_core::SigningKey::deserialize(&secret.to_bytes())?;
     frost::keys::split(&frost_secret, max_signers, min_signers, identifiers, rng)
 }
 

--- a/crates/crypto/decaf377-frost/src/keys/dkg.rs
+++ b/crates/crypto/decaf377-frost/src/keys/dkg.rs
@@ -33,11 +33,13 @@ pub mod round1 {
                         .0
                         .commitment()
                         .serialize()
-                        .into_iter()
-                        .map(|x| x.to_vec())
-                        .collect(),
+                        .expect("VSS commitment serialization is valid"),
                 }),
-                proof_of_knowledge: value.0.proof_of_knowledge().serialize().to_vec(),
+                proof_of_knowledge: value
+                    .0
+                    .proof_of_knowledge()
+                    .serialize()
+                    .expect("proof of knowledge serialization is valid"),
             }
         }
     }
@@ -53,7 +55,7 @@ pub mod round1 {
                         .ok_or(anyhow!("DkgRound1Package missing commitment"))?
                         .elements,
                 )?,
-                frost_core::Signature::deserialize(value.proof_of_knowledge)?,
+                frost_core::Signature::deserialize(&value.proof_of_knowledge)?,
             )))
         }
     }
@@ -103,7 +105,7 @@ pub mod round2 {
         fn try_from(value: pb::DkgRound2Package) -> Result<Self, Self::Error> {
             Ok(Self(frost::keys::dkg::round2::Package::new(
                 frost::keys::SigningShare::deserialize(
-                    value
+                    &value
                         .signing_share
                         .ok_or(anyhow!("DkgRound2Package missing signing share"))?
                         .scalar,

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -67,13 +67,13 @@ pub mod round1 {
         fn try_from(value: pb::SigningNonces) -> Result<Self, Self::Error> {
             Ok(Self(frost::round1::SigningNonces::from_nonces(
                 frost::round1::Nonce::deserialize(
-                    value
+                    &value
                         .hiding
                         .ok_or(anyhow!("SigningNonces missing hiding"))?
                         .scalar,
                 )?,
                 frost::round1::Nonce::deserialize(
-                    value
+                    &value
                         .binding
                         .ok_or(anyhow!("SigningNonces missing binding"))?
                         .scalar,
@@ -138,10 +138,10 @@ pub mod round1 {
         fn from(value: SigningCommitments) -> Self {
             Self {
                 hiding: Some(pb::NonceCommitment {
-                    element: value.0.hiding().serialize(),
+                    element: value.0.hiding().serialize().expect("serialization"),
                 }),
                 binding: Some(pb::NonceCommitment {
-                    element: value.0.binding().serialize(),
+                    element: value.0.binding().serialize().expect("serialization"),
                 }),
             }
         }
@@ -153,13 +153,13 @@ pub mod round1 {
         fn try_from(value: pb::SigningCommitments) -> Result<Self, Self::Error> {
             Ok(Self(frost::round1::SigningCommitments::new(
                 frost::round1::NonceCommitment::deserialize(
-                    value
+                    &value
                         .hiding
                         .ok_or(anyhow!("SigningCommitments missing hiding"))?
                         .element,
                 )?,
                 frost::round1::NonceCommitment::deserialize(
-                    value
+                    &value
                         .binding
                         .ok_or(anyhow!("SigningCommitments missing binding"))?
                         .element,
@@ -272,7 +272,7 @@ pub mod round2 {
 
         fn try_from(value: pb::SignatureShare) -> Result<Self, Self::Error> {
             Ok(Self(frost::round2::SignatureShare::deserialize(
-                value.scalar,
+                &value.scalar,
             )?))
         }
     }
@@ -341,7 +341,8 @@ pub fn aggregate(
         .map(|(a, b)| (*a, b.0.clone()))
         .collect();
     let frost_sig = frost::aggregate(&signing_package.0, &signature_shares, pubkeys)?;
-    Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
+    let bytes = frost_sig.serialize()?;
+    Ok(TryInto::<[u8; 64]>::try_into(bytes)
         .expect("serialization is valid")
         .into())
 }
@@ -367,7 +368,8 @@ pub fn aggregate_randomized(
             frost_rerandomized::Randomizer::from_scalar(randomizer),
         ),
     )?;
-    Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
+    let bytes = frost_sig.serialize()?;
+    Ok(TryInto::<[u8; 64]>::try_into(bytes)
         .expect("serialization is valid")
         .into())
 }

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -70,8 +70,8 @@ impl Group for Decaf377Group {
         decaf377::Element::GENERATOR
     }
 
-    fn serialize(element: &Self::Element) -> Self::Serialization {
-        element.vartime_compress().0.to_vec()
+    fn serialize(element: &Self::Element) -> Result<Self::Serialization, GroupError> {
+        Ok(element.vartime_compress().0.to_vec())
     }
 
     fn deserialize(buf: &Self::Serialization) -> Result<Self::Element, GroupError> {

--- a/crates/crypto/decaf377-frost/tests/frost.rs
+++ b/crates/crypto/decaf377-frost/tests/frost.rs
@@ -107,8 +107,9 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
         .unwrap()
         .verifying_key()
         .serialize()
+        .expect("serialize should not fail")
         .try_into()
-        .expect("serialize should not fail");
+        .expect("serialization should be 32 bytes");
     let vk = VerificationKey::<SpendAuth>::try_from(vk_bytes)?;
 
     // Verify the signature


### PR DESCRIPTION
bumping the frost dep now to v2.1.0 to allow for serializing dkg round 1 & 2 `SecretPackages`. 

These are necessary downstream by the clients consuming `decaf377-frost`. 