### PR TITLE
refactor: make audit friendly 

### DIFF
--- a/.github/workflows/bluesky.yml
+++ b/.github/workflows/bluesky.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   post_on_merge:
-    if: github.event.pull_request.merged == true
+    # Disabled for Cycles fork
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: myConsciousness/bluesky-post@v3

--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -36,19 +36,17 @@ jobs:
               echo "OK: no changes required to buf.lock"
           fi
 
-      - name: Check for breaking changes
-        uses: bufbuild/buf-breaking-action@v1
-        with:
-          input: "proto"
-          # The 'main' branch of the GitHub repository that defines the module.
-          # Don't use `GITHUB_REPOSITORY`, because then it'll fail when run on forks.
-          # against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=proto"
-          against: "https://github.com/penumbra-zone/penumbra.git#branch=main,subdir=proto"
+      # Disabled for Cycles fork - we intentionally diverge from upstream Penumbra protos.
+      # - name: Check for breaking changes
+      #   uses: bufbuild/buf-breaking-action@v1
+      #   with:
+      #     input: "proto"
+      #     against: "https://github.com/penumbra-zone/penumbra.git#branch=main,subdir=proto"
 
   # Run our bespoke tooling for codegen, consuming the protocol buffer definitions
   # and emitting generated code. Afterward, there should be no uncommitted changes.
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   publish:
+    # Disabled for Cycles fork - enable when BSR publishing is needed
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,7 +12,9 @@ on:
   workflow_dispatch:
 jobs:
   penumbra:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    # Disabled for Cycles fork - update image path to ghcr.io/informalsystems/penumbra when needed
+    if: false
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   publish:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    # Disabled for Cycles fork - enable with CARGO_REGISTRY_TOKEN when publishing to crates.io
+    if: false
+    runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   rustdocs:
+    # Disabled for Cycles fork - we don't deploy rustdocs and this requires LFS + nightly
+    if: false
     # We use a custom script to generate the index page for https://rustdoc.penumbra.zone,
     # and refactors to rust deps can break that generation. Let's ensure this script exits 0
     # on PRs, but we'll still only deploy after merge into main.
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,8 +39,10 @@ jobs:
   # Also validate that the `mdbook` docs (guide & protocol) build correctly.
   # In particular, links are checked within the docs.
   mdbook:
+    # Disabled for Cycles fork - mdbook-mermaid requires edition2024 (not stable in Cargo 1.83)
+    if: false
     # Downgrading runner size to 4vcpu, since we're not compiling code.
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +55,7 @@ jobs:
       # It's OK to install from crates, building from source, because the
       # rust-cache restore on the previous step reduces the install step to ~5s.
       - name: Install mdbook dependencies
-        run: cargo install mdbook mdbook-katex mdbook-mermaid mdbook-linkcheck
+        run: cargo install --locked mdbook mdbook-katex mdbook-mermaid mdbook-linkcheck
 
       - name: Build protocol docs
         run: cd docs/protocol && mdbook build

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -12,8 +12,10 @@ jobs:
   # Would be faster if we parallelized it, but it's already <10m,
   # and only runs post-merge on main, so 10m isn't bad.
   build:
+    # Disabled for Cycles fork - needs Firebase config for deployment
+    if: false
     timeout-minutes: 30
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
+    # Disabled for Cycles fork - enable when creating releases
+    if: false
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,10 +28,9 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          backend: buildjet
 
       - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
+        uses: Swatinem/rust-cache@v2
 
       # The `rust-toolchain.toml` file dictates which version of rust to setup.
       - name: check rust version
@@ -58,7 +57,7 @@ jobs:
   # As of 2025Q1, the "features" job is the slowest in the CI suite.
   # Consider moving to a scheduled job on main, rather than running on PRs.
   features:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,10 +71,9 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          backend: buildjet
 
       - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
+        uses: Swatinem/rust-cache@v2
 
       # Build each crate separately, to validate that the feature-gating is working.
       # This is a lighter-weight version of `cargo check-all-features --workspace --release`.
@@ -86,7 +84,7 @@ jobs:
         run: nix develop --command ./deployments/scripts/check-wasm-compat.sh
 
   test:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,10 +98,9 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          backend: buildjet
 
       - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests with nextest
         run: nix develop --command just test

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    # Disabled for Cycles fork - requires full devnet setup and LFS assets for pd binary
+    if: false
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,7 +42,9 @@ jobs:
         run: nix develop --command just smoke
 
   pmonitor:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    # Disabled for Cycles fork - requires building pd/pcli/pmonitor binaries (needs LFS)
+    if: false
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,7 +70,7 @@ jobs:
   # Temporarily disabling these in CI, as the testnet endpoints are
   # incompatible with `main`, given GH5010.
   # testnet:
-  #   runs-on: buildjet-16vcpu-ubuntu-2204
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v4
   #       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,10 +1519,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-crc32"
-version = "1.3.0"
+name = "const-crc32-nostd"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d13f542d70e5b339bf46f6f74704ac052cfd526c58cd87996bd1ef4615b9a0"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1913,10 +1913,10 @@ checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
 [[package]]
 name = "decaf377"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2097c5f69d06259112bea2024ddc41095c5001b503448f84ac169efc7cc8fd75"
+source = "git+https://github.com/informalsystems/decaf377.git#0945efd1eaf5e2d45441eb99c6f3a0cb3b928512"
 dependencies = [
  "ark-bls12-377",
+ "ark-crypto-primitives",
  "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -1962,8 +1962,11 @@ dependencies = [
  "decaf377-rdsa",
  "frost-core",
  "frost-rerandomized",
+ "getrandom",
+ "hex",
  "penumbra-sdk-proto",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -1983,11 +1986,9 @@ dependencies = [
 [[package]]
 name = "decaf377-rdsa"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437967a34e0699b50b986a72ce6c4e2e5930bde85ec8f3749701f7e50d6d32b0"
+source = "git+https://github.com/informalsystems/decaf377-rdsa.git#140b31b2783d19392a5f8d9fd98c65e80f55129e"
 dependencies = [
  "ark-ff",
- "ark-serialize",
  "blake2b_simd 0.5.11",
  "decaf377",
  "digest 0.9.0",
@@ -2046,13 +2047,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2 1.0.93",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2567,35 +2568,36 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "0.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b61d737e19bea0cedda9a11dab96ab1fd1e4016f707e8ee9018d8f17d2cd18"
+checksum = "2619366c227233c0f817ae01156bd21b8cf74d2bd96cbe0889f4c2e266724e44"
 dependencies = [
  "byteorder",
- "const-crc32",
+ "const-crc32-nostd",
  "debugless-unwrap",
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "postcard",
  "rand_core",
  "serde",
  "serdect",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "visibility",
  "zeroize",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "0.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b45409d93cf5000f52ae64847a8a270a4562f1a035e74c3fae0e2462adb97ae"
+checksum = "4c5eb1ea58c0250b7ce834337f7b19e0417686d14ffc7f626137dea9149762d4"
 dependencies = [
  "derive-getters",
  "document-features",
  "frost-core",
+ "hex",
  "rand_core",
 ]
 
@@ -3802,6 +3804,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -5296,19 +5307,13 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "base64 0.21.7",
- "bech32",
  "blake2b_simd 1.0.2",
- "bytes",
  "decaf377",
  "decaf377-fmd",
  "decaf377-rdsa",
- "derivative",
- "ethnum",
  "getrandom",
  "hex",
- "ibig",
  "lazy_static",
- "num-bigint",
  "once_cell",
  "pbjson-types",
  "penumbra-sdk-num",
@@ -5321,9 +5326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.10.8",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -6767,8 +6770,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 [[package]]
 name = "poseidon-parameters"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6df50e93cde74d26eb66c9674fccde32172e915a420fe2a73fda39ab377f709"
+source = "git+https://github.com/informalsystems/poseidon377.git#a0c3e64341d104f1c7f7127a959a28f4585f127f"
 dependencies = [
  "decaf377",
 ]
@@ -6776,8 +6778,7 @@ dependencies = [
 [[package]]
 name = "poseidon-permutation"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c4e1e8d622017ece288f1a1b06f0bfeaacaa4166fa155a91103317299452e2"
+source = "git+https://github.com/informalsystems/poseidon377.git#a0c3e64341d104f1c7f7127a959a28f4585f127f"
 dependencies = [
  "ark-ff",
  "ark-r1cs-std",
@@ -6790,8 +6791,7 @@ dependencies = [
 [[package]]
 name = "poseidon377"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0544874afdaf74b69efc90795c66ea7a494faeb2981a0585d46c757ee2fa94"
+source = "git+https://github.com/informalsystems/poseidon377.git#a0c3e64341d104f1c7f7127a959a28f4585f127f"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,10 +126,10 @@ cnidarium                        = { version = "0.83", default-features = false}
 cnidarium-component              = { default-features = false, version = "2.0.4", path = "crates/cnidarium-component" }
 cometindex                       = { version = "2.0.4", path = "crates/util/cometindex" }
 criterion                        = { version = "0.4" }
-decaf377                         = { default-features = false, version = "0.10.1" }
-decaf377-fmd                     = { version = "2.0.4", path = "crates/crypto/decaf377-fmd" }
-decaf377-ka                      = { version = "2.0.4", path = "crates/crypto/decaf377-ka" }
-decaf377-rdsa                    = { version = "0.11.0" }
+decaf377                         = { default-features = false, git = "https://github.com/informalsystems/decaf377.git" }
+decaf377-fmd                     = { default-features = false, path = "crates/crypto/decaf377-fmd" }
+decaf377-ka                      = { default-features = false, path = "crates/crypto/decaf377-ka" }
+decaf377-rdsa                    = { default-features = false, git = "https://github.com/informalsystems/decaf377-rdsa.git" }
 derivative                       = { version = "2.2" }
 directories                      = { version = "4.0.1" }
 ed25519-consensus                = { version = "2.1" }
@@ -191,11 +191,11 @@ penumbra-sdk-view                    = { version = "2.0.4", path = "crates/view"
 penumbra-sdk-wallet                  = { version = "2.0.4", path = "crates/wallet" }
 pin-project                      = { version = "1.0.12" }
 pin-project-lite                 = { version = "0.2.9" }
-poseidon377                      = { version = "1.2.0" }
+poseidon377                      = { version = "1.2.0", git = "https://github.com/informalsystems/poseidon377.git", default-features = false }
 proptest                         = { version = "1.6" }
 proptest-derive                  = { version = "0.5.1" }
-prost-types                      = { version = "0.13.4" }
 prost                            = { version = "0.13.4" }
+prost-types                      = { version = "0.13.4" }
 r2d2                             = { version = "0.8" }
 r2d2_sqlite                      = { version = "0.25" }
 rand                             = { version = "0.8.5" }

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -1,0 +1,105 @@
+# Penumbra Fork Changes for Cycles Protocol
+
+Base: Penumbra `v2.0.4` (commit `6cefeb7f4`)
+Branch: `v2.0.4-audit`
+
+## Summary
+
+| Change | Security Impact | Commit |
+|--------|-----------------|--------|
+| Redirect to Informal Systems forks of decaf377, decaf377-rdsa, poseidon377 | Medium — forks contain Cycles-specific modifications | `6df4a462e` |
+| Bech32 HRPs `penumbra*` → `cycles*` (addresses, validator keys, asset registry) | Low — encoding only, ensures domain separation from Penumbra mainnet | `f046b480c`, `bd687e260` |
+| Expose `tct::Hash` publicly | Medium — extends public API surface | `d8e3c8651` |
+| Rseed type `[u8; 32]` → `Fq` | High — changes note blinding derivation | `947e22b94` |
+| RCM domain separator → Poseidon with `cycles.derive.rcm` | High — changes commitment randomness | `947e22b94` |
+| Upgrade frost-core to 2.2.0 and expose serialization types | Medium — API changes in threshold signing | `ebf3f7ee8` |
+| Feature gates for WASM/CosmWasm compatibility | Low — compile-time only, all enabled by default | `a1fa2ee09` |
+| CI adapted for fork (exclusions, disabled jobs, test ignores) | None | `bd687e260` |
+
+All commit hashes reference the `v2.0.4-audit` branch.
+
+## Forked Dependencies
+
+| Crate | Fork Repo | Cargo.lock SHA |
+|-------|-----------|----------------|
+| decaf377 | [informalsystems/decaf377](https://github.com/informalsystems/decaf377) | `0945efd1` |
+| decaf377-rdsa | [informalsystems/decaf377-rdsa](https://github.com/informalsystems/decaf377-rdsa) | `140b31b2` |
+| poseidon377 | [informalsystems/poseidon377](https://github.com/informalsystems/poseidon377) | `a0c3e643` |
+
+Note: These SHAs are pinned via `Cargo.lock`, not via `rev =` in `Cargo.toml`. Builds are
+reproducible as long as `Cargo.lock` is respected (i.e. no `cargo update`). The forks are not
+identical to upstream — they contain modifications required by Cycles (e.g. `Fq`-based rseed
+support in decaf377, rand feature gating).
+
+## Detailed Changes
+
+### 1. Dependency Redirects (`6df4a462e`)
+
+Workspace `Cargo.toml` points `decaf377`, `decaf377-rdsa`, and `poseidon377` to Informal Systems
+forks via git URLs. These forks carry Cycles-specific modifications — auditors should review the
+fork diffs against their upstream counterparts.
+
+### 2. Bech32 Prefix Rename (`f046b480c`, `bd687e260`)
+
+All human-readable parts changed from `penumbra*` to `cycles*`:
+- `penumbra` → `cycles` (addresses)
+- `penumbravalid` → `cyclesvalid` (validator identity keys)
+- `penumbragovern` → `cyclesgovern` (governance keys)
+- `penumbrafullviewingkey` → `cyclesfullviewingkey`
+- `penumbrawalletid` → `cycleswalletid`
+- `penumbraspendkey` → `cyclesspendkey`
+- `penumbracompat1` → `cyclescompat1`
+
+Hardcoded test keys regenerated to match. Validator identity regex patterns in the asset
+registry (`registry.rs`) and token types (`delegation_token.rs`, `unbonding_token.rs`) also
+updated from `penumbravalid1` to `cyclesvalid1`.
+
+### 3. Expose `tct::Hash` (`d8e3c8651`)
+
+Re-exports `internal::hash::Hash` from the TCT crate's public API. Required by Cycles for
+direct tree hash operations.
+
+### 4. Rseed Type and RCM Domain Separator (`947e22b94`)
+
+**Rseed type change:** `Rseed` inner type changed from `[u8; 32]` to `Fq`. This allows direct
+use in arithmetic circuits without an intermediate conversion step. `From` impls provided for
+`[u8; 32]`, `&[u8; 32]`, and `&[u8]` to maintain ergonomic construction from byte arrays.
+
+**RCM derivation change:** Note commitment randomness (`derive_note_blinding`) changed from
+PRF-expand with domain separator `Penumbra_DeriRcm` to a Poseidon hash with domain separator
+`cycles.derive.rcm`. This is a **cryptographic domain separation** — notes created by Cycles
+are not valid on Penumbra and vice versa.
+
+**Files affected:** `rseed.rs`, `note.rs`, `backref.rs`, `note_manager.rs`, `note_record.rs`,
+`storage.rs`, bench files, test vector generation.
+
+### 5. FROST Upgrade (`ebf3f7ee8`)
+
+Upgrade `frost-core` and `frost-rerandomized` from 0.7 to 2.2.0 (pinned to exact version in
+`decaf377-frost/Cargo.toml`). Adapt `decaf377-frost` to the new API. Add proto definitions for
+frost key shares. Cycles requires publicly exposed frost types and their serialization impls
+for threshold signing, which were private in the 0.7 API.
+
+### 6. Feature Gates (`a1fa2ee09`)
+
+Optional feature flags added across crypto and core crates:
+- `rand` — gates randomness-dependent code (`generate`, `dummy`, `new` constructors)
+- `r1cs` — gates constraint system types (`NoteVar`, proof circuits)
+- `ibc` — gates IBC-specific types (`Ics20Withdrawal`)
+- `tendermint` — gates tendermint type conversions
+
+This allows downstream consumers (CosmWasm contracts) to depend on these crates without pulling
+in networking, randomness, or proving system dependencies that don't compile for WASM targets.
+
+No behavioral changes when built with default features. When features are disabled
+(e.g. `default-features = false` for WASM targets), gated code is excluded from compilation.
+
+### 7. CI Adaptations (`bd687e260`)
+
+- Exclude binary crates requiring LFS (`pd`, `pcli`, `pclientd`, `pmonitor`, `pindexer`)
+- Exclude custody chain crates (`penumbra-sdk-custody`, `penumbra-sdk-wallet`, `penumbra-sdk-app-tests`, `elcuity`)
+- Reduce WASM compatibility checks to Cycles-relevant crates only
+- Disable Penumbra-specific CI jobs via `if: false` (bluesky, buf-push, containers, crates, docs-lint, notes, release, smoke)
+- Active workflows: `rust.yml` (lint, check, test, WASM compat) and `buf-pull-request.yml` (protobuf)
+- Ignore divergent `effect_hash_test_vectors` test (hashes differ due to rseed/RCM changes)
+- Switch rust cache from BuildJet (`astriaorg/buildjet-rust-cache`) to `Swatinem/rust-cache@v2`

--- a/crates/bench/benches/nullifier_derivation.rs
+++ b/crates/bench/benches/nullifier_derivation.rs
@@ -38,7 +38,7 @@ fn nullifier_derivation_proving_time(c: &mut Criterion) {
     let note = Note::from_parts(
         address,
         Value::from_str("1upenumbra").expect("valid value"),
-        Rseed([1u8; 32]),
+        Rseed::from([1u8; 32]),
     )
     .expect("can make a note");
     let nullifier = Nullifier(Fq::from(1u64));

--- a/crates/bench/benches/output.rs
+++ b/crates/bench/benches/output.rs
@@ -35,7 +35,8 @@ fn output_proving_time(c: &mut Criterion) {
     .expect("generated 1 address");
     let value_to_send = Value::from_str("1upenumbra").expect("valid value");
 
-    let note = Note::from_parts(address, value_to_send, Rseed([1u8; 32])).expect("can make a note");
+    let note =
+        Note::from_parts(address, value_to_send, Rseed::from([1u8; 32])).expect("can make a note");
     let balance_blinding = Fr::from(1u32);
     let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
     let note_commitment = note.commit();

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -8,7 +8,7 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
-default = []
+default = ["rand", "decaf377/arkworks"]
 parallel = [
     "ark-ff/parallel",
     "poseidon377/parallel",
@@ -16,6 +16,15 @@ parallel = [
     "ark-std/parallel",
     "ark-r1cs-std/parallel",
     "decaf377/parallel",
+]
+rand = [
+    "dep:rand_core",
+    "dep:rand",
+    "dep:getrandom",
+    "decaf377/rand",
+    "decaf377-fmd/rand", 
+    "decaf377-rdsa/rand",
+    "penumbra-sdk-num/rand",
 ]
 
 [dependencies]
@@ -26,34 +35,26 @@ ark-relations = {workspace = true}
 ark-serialize = {workspace = true}
 ark-std = {workspace = true, default-features = false}
 base64 = {workspace = true}
-bech32 = {workspace = true}
 blake2b_simd = {workspace = true}
-bytes = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-fmd = {workspace = true}
-decaf377-rdsa = {workspace = true}
-derivative = {workspace = true}
-ethnum = {workspace = true}
-getrandom = {workspace = true, features = ["js"]}
-hex = {workspace = true}
-ibig = {workspace = true}
-num-bigint = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = false}
+decaf377-fmd = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true, default-features = false}
+getrandom = {workspace = true, features = ["js"], optional = true}
 once_cell = {workspace = true}
-penumbra-sdk-num = {workspace = true, default-features = true}
-penumbra-sdk-proto = {workspace = true, default-features = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-sdk-num = {workspace = true, default-features = false}
+penumbra-sdk-proto = {workspace = true, default-features = false}
+poseidon377 = {workspace = true, features = ["r1cs"], default-features = false}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_with = {workspace = true}
-sha2 = {workspace = true}
 thiserror = {workspace = true}
-tracing = {workspace = true}
 pbjson-types = {workspace = true}
 lazy_static = "1.5.0"
 
 [dev-dependencies]
+hex = {workspace = true}
 proptest = {workspace = true}
 serde_json = {workspace = true}
 getrandom = {workspace = true}

--- a/crates/core/asset/src/asset/registry.rs
+++ b/crates/core/asset/src/asset/registry.rs
@@ -330,10 +330,10 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
             // Note: this regex must be in sync with DelegationToken::try_from
             // and VALIDATOR_IDENTITY_BECH32_PREFIX in the penumbra-stake crate
             // TODO: this doesn't restrict the length of the bech32 encoding
-            "^udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
+            "^udelegation_(?P<data>cyclesvalid1[a-zA-HJ-NP-Z0-9]+)$",
             &[
-                "^delegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
-                "^mdelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
+                "^delegation_(?P<data>cyclesvalid1[a-zA-HJ-NP-Z0-9]+)$",
+                "^mdelegation_(?P<data>cyclesvalid1[a-zA-HJ-NP-Z0-9]+)$",
             ],
             (|data: &str| {
                 assert!(!data.is_empty());
@@ -356,10 +356,10 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
             // Note: this regex must be in sync with UnbondingToken::try_from
             // and VALIDATOR_IDENTITY_BECH32_PREFIX in the penumbra-stake crate
             // TODO: this doesn't restrict the length of the bech32 encoding
-            "^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1[a-zA-HJ-NP-Z0-9]+))$",
+            "^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>cyclesvalid1[a-zA-HJ-NP-Z0-9]+))$",
             &[
-                "^unbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1[a-zA-HJ-NP-Z0-9]+))$",
-                "^munbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1[a-zA-HJ-NP-Z0-9]+))$",
+                "^unbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>cyclesvalid1[a-zA-HJ-NP-Z0-9]+))$",
+                "^munbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>cyclesvalid1[a-zA-HJ-NP-Z0-9]+))$",
             ],
             (|data: &str| {
                 assert!(!data.is_empty());

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -70,7 +70,7 @@ penumbra-sdk-num = {workspace = true, default-features = false}
 penumbra-sdk-proof-params = {workspace = true, default-features = true}
 penumbra-sdk-proto = {workspace = true, default-features = false}
 penumbra-sdk-sct = {workspace = true, default-features = false}
-penumbra-sdk-shielded-pool = {workspace = true, default-features = false}
+penumbra-sdk-shielded-pool = {workspace = true, default-features = false, features = ["rand"]}
 penumbra-sdk-tct = {workspace = true, default-features = false}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
 poseidon377 = {workspace = true, features = ["r1cs"]}

--- a/crates/core/component/dex/src/swap/plaintext.rs
+++ b/crates/core/component/dex/src/swap/plaintext.rs
@@ -57,8 +57,8 @@ impl SwapPlaintext {
         let rseed_1_hash = hash_1(&OUTPUT_1_BLINDING_DOMAIN_SEPARATOR, fq_rseed);
         let rseed_2_hash = hash_1(&OUTPUT_2_BLINDING_DOMAIN_SEPARATOR, fq_rseed);
         (
-            Rseed(rseed_1_hash.to_bytes()),
-            Rseed(rseed_2_hash.to_bytes()),
+            Rseed::from(rseed_1_hash.to_bytes()),
+            Rseed::from(rseed_2_hash.to_bytes()),
         )
     }
 
@@ -317,7 +317,7 @@ impl TryFrom<pb::SwapPlaintext> for SwapPlaintext {
                 .trading_pair
                 .ok_or_else(|| anyhow::anyhow!("missing trading pair in SwapPlaintext"))?
                 .try_into()?,
-            rseed: Rseed(plaintext.rseed.as_slice().try_into()?),
+            rseed: Rseed::from(plaintext.rseed.as_slice()),
         })
     }
 }
@@ -401,7 +401,7 @@ impl TryFrom<&[u8]> for SwapPlaintext {
                 asset_id: asset::Id::try_from(fee_asset_id_bytes)?,
             }),
             claim_address: pb_address.try_into()?,
-            rseed: Rseed(rseed),
+            rseed: Rseed::from(rseed),
         })
     }
 }

--- a/crates/core/component/dex/src/swap/proof.rs
+++ b/crates/core/component/dex/src/swap/proof.rs
@@ -174,7 +174,7 @@ impl DummyWitness for SwapCircuit {
                     .id(),
             }),
             claim_address: address,
-            rseed: Rseed([1u8; 32]),
+            rseed: Rseed::from([1u8; 32]),
         };
 
         Self {
@@ -320,7 +320,7 @@ mod tests {
             let delta_2_i = Amount::from(0u64);
             let fee = Fee::default();
 
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
             let swap_plaintext = SwapPlaintext {
                 trading_pair,
                 delta_1_i,
@@ -382,7 +382,7 @@ mod tests {
             let delta_2_i = Amount::from(0u64);
             let fee = Fee::default();
 
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
             let swap_plaintext = SwapPlaintext {
                 trading_pair,
                 delta_1_i,

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -336,7 +336,7 @@ impl DummyWitness for SwapClaimCircuit {
                     .id(),
             }),
             claim_address: address,
-            rseed: Rseed([1u8; 32]),
+            rseed: Rseed::from([1u8; 32]),
         };
         let mut sct = tct::Tree::new();
         let swap_commitment = swap_plaintext.swap_commitment();
@@ -611,7 +611,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,
@@ -743,7 +743,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,
@@ -834,7 +834,7 @@ mod tests {
         let delta_2_i = Amount::from(0u64);
         let fee = Fee::default();
 
-        let rseed = Rseed(rseed_randomness);
+        let rseed = Rseed::from(rseed_randomness);
         let swap_plaintext = SwapPlaintext {
             trading_pair,
             delta_1_i,

--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -15,9 +15,17 @@ component = [
     "tonic",
     "penumbra-sdk-proto/rpc"
 ]
-default = ["std", "component"]
+default = ["std", "component", "rand", "decaf377/arkworks"]
 std = ["ark-ff/std"]
 docsrs = []
+rand = [
+    "rand_core",
+    "dep:rand",
+    "decaf377/rand",
+    "decaf377-rdsa/rand",
+    "penumbra-sdk-asset/rand",
+    "penumbra-sdk-num/rand",
+]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -27,15 +35,15 @@ blake2b_simd = {workspace = true}
 bytes = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, default-features = true}
+decaf377 = {workspace = true}
 decaf377-rdsa = {workspace = true}
 im = {workspace = true}
 metrics = {workspace = true}
-penumbra-sdk-asset = {workspace = true, default-features = false}
-penumbra-sdk-num = {workspace = true, default-features = false}
-penumbra-sdk-proto = {workspace = true, default-features = false}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-sdk-asset = {workspace = true}
+penumbra-sdk-num = {workspace = true}
+penumbra-sdk-proto = {workspace = true}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 serde = {workspace = true, features = ["derive"]}
 tendermint = {workspace = true}
 tonic = {workspace = true, optional = true}

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -256,7 +256,7 @@ impl DummyWitness for DelegatorVoteCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1u64);
@@ -459,7 +459,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -472,7 +472,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("can insert note commitment into SCT");
             }
@@ -484,7 +484,7 @@ mod tests {
             // All proposals should have a position commitment index of zero, so we need to end the epoch
             // and get the position that corresponds to the first commitment in the new epoch.
             sct.end_epoch().expect("should be able to end an epoch");
-            let first_note_commitment = Note::from_parts(sender.clone(), value_to_send, Rseed([u8::MAX; 32])).expect("can create note").commit();
+            let first_note_commitment = Note::from_parts(sender.clone(), value_to_send, Rseed::from([u8::MAX; 32])).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, first_note_commitment).expect("can insert note commitment into SCT");
             let start_position = sct.witness(first_note_commitment).expect("can witness note commitment").position();
 
@@ -535,7 +535,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -548,7 +548,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("can insert note commitment into SCT");
             }
@@ -557,7 +557,7 @@ mod tests {
             let anchor = sct.root();
             let state_commitment_proof = sct.witness(note_commitment).expect("can witness note commitment");
 
-            let rseed = Rseed([num_commitments as u8; 32]);
+            let rseed = Rseed::from([num_commitments as u8; 32]);
             let not_first_note_commitment = Note::from_parts(sender, value_to_send, rseed).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, not_first_note_commitment).expect("can insert note commitment into SCT");
             // All proposals should have a position commitment index of zero, but this one will not, so

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = {workspace = true}
 pbjson-types = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-num = {workspace = true, default-features = false}
-penumbra-sdk-proto = {workspace = true, default-features = false}
+penumbra-sdk-proto = {workspace = true, features = ["ibc"]}
 penumbra-sdk-sct = {workspace = true, default-features = false}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
 prost = {workspace = true}

--- a/crates/core/component/ibc/src/version.rs
+++ b/crates/core/component/ibc/src/version.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "component")]
 use ibc_types::core::connection::Version;
 
 /// Selects a version from the intersection of locally supported and counterparty versions.
+#[cfg(feature = "component")]
 pub fn pick_connection_version(
     supported_versions: &[Version],
     counterparty_versions: &[Version],

--- a/crates/core/component/sct/Cargo.toml
+++ b/crates/core/component/sct/Cargo.toml
@@ -15,9 +15,17 @@ component = [
     "penumbra-sdk-proto/rpc",
     "tonic",
 ]
-default = ["std", "component"]
+default = ["std", "component", "rand", "decaf377/arkworks", "penumbra-sdk-proto/tendermint"]
 std = ["ark-ff/std"]
 docsrs = []
+rand = [
+    "rand_core",
+    "dep:rand",
+    "decaf377/rand",
+    "decaf377-rdsa/rand",
+    "penumbra-sdk-keys/rand",
+    "penumbra-sdk-tct/rand",
+]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -31,7 +39,7 @@ blake2b_simd = {workspace = true}
 bytes = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-rdsa = {workspace = true}
 hex = {workspace = true}
 im = {workspace = true}
@@ -40,11 +48,11 @@ once_cell = {workspace = true}
 pbjson-types = {workspace = true}
 penumbra-sdk-keys = {workspace = true, default-features = false}
 penumbra-sdk-proto = {workspace = true, default-features = false}
-penumbra-sdk-tct = {workspace = true, default-features = true}
+penumbra-sdk-tct = {workspace = true}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
 poseidon377 = {workspace = true, features = ["r1cs"]}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 serde = {workspace = true, features = ["derive"]}
 tendermint = {workspace = true}
 tonic = {workspace = true, optional = true}

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -17,30 +17,54 @@ component = [
     "tonic",
     "ibc-proto/server",
     "ibc-proto/transport",
+    "ibc",
+    "penumbra-sdk-ibc"
 ]
-# proving-keys = ["penumbra-sdk-proof-params/proving-keys"]
-default = ["std", "component"]
+ibc = ["dep:ibc-types", "penumbra-sdk-ibc"]
+default = ["std", "component", "rand", "r1cs", "decaf377/arkworks", "penumbra-sdk-proto/tendermint"]
 std = ["ark-ff/std"]
 parallel = [
     "penumbra-sdk-tct/parallel",
     "ark-ff/parallel",
     "poseidon377/parallel",
     "decaf377-rdsa/parallel",
-    "ark-groth16/parallel",
-    "ark-r1cs-std/parallel",
+    "ark-groth16?/parallel",
+    "ark-r1cs-std?/parallel",
     "decaf377/parallel",
     "tonic",
 ]
 docsrs = []
+rand = [
+    "rand_core",
+    "dep:rand",
+    "decaf377/rand",
+    "decaf377-fmd/rand",
+    "decaf377-ka/rand",
+    "decaf377-rdsa/rand",
+    "penumbra-sdk-asset/rand",
+    "penumbra-sdk-num/rand",
+    "penumbra-sdk-keys/rand",
+    "penumbra-sdk-sct/rand",
+    "penumbra-sdk-tct/rand",
+    "penumbra-sdk-proof-params/rand",
+]
+r1cs = [
+    "dep:ark-groth16",
+    "dep:ark-r1cs-std",
+    "dep:ark-relations",
+    "dep:ark-snark",
+    "decaf377/r1cs",
+    "poseidon377/r1cs",
+]
 
 [dependencies]
 anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
-ark-groth16 = {workspace = true, default-features = false}
-ark-r1cs-std = {workspace = true, default-features = false}
-ark-relations = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false, optional = true}
+ark-r1cs-std = {workspace = true, default-features = false, optional = true}
+ark-relations = {workspace = true, optional = true}
 ark-serialize = {workspace = true}
-ark-snark = {workspace = true}
+ark-snark = {workspace = true, optional = true}
 async-stream = {workspace = true}
 async-trait = {workspace = true}
 base64 = {workspace = true}
@@ -49,30 +73,30 @@ bytes = {workspace = true}
 chacha20poly1305 = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-fmd = {workspace = true}
-decaf377-ka = {workspace = true}
-decaf377-rdsa = {workspace = true}
+decaf377 = {workspace = true, default-features = false}
+decaf377-fmd = {workspace = true, default-features = false}
+decaf377-ka = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true, default-features = false}
 futures = {workspace = true}
 hex = {workspace = true}
 ibc-proto = {workspace = true, default-features = false}
-ibc-types = {workspace = true, features = ["with_serde"], default-features = false}
+ibc-types = {workspace = true, features = ["with_serde"], default-features = false, optional = true}
 im = {workspace = true}
 metrics = {workspace = true}
 once_cell = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
-penumbra-sdk-ibc = {workspace = true, default-features = false}
+penumbra-sdk-ibc = {workspace = true, default-features = false, optional = true }
 penumbra-sdk-keys = {workspace = true, default-features = false}
 penumbra-sdk-num = {workspace = true, default-features = false}
 penumbra-sdk-proof-params = {workspace = true, default-features = false}
 penumbra-sdk-proto = {workspace = true, default-features = false}
 penumbra-sdk-sct = {workspace = true, default-features = false}
-penumbra-sdk-tct = {workspace = true, default-features = true}
+penumbra-sdk-tct = {workspace = true, default-features = false}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
-poseidon377 = {workspace = true, features = ["r1cs"]}
+poseidon377 = {workspace = true, default-features = false}
 prost = {workspace = true}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}

--- a/crates/core/component/shielded-pool/src/backref.rs
+++ b/crates/core/component/shielded-pool/src/backref.rs
@@ -156,7 +156,7 @@ mod tests {
                     .unwrap()
                     .id(),
             };
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
 
             let note = Note::from_parts(sender, value_to_send, rseed).expect("valid note");
             let note_commitment: penumbra_sdk_tct::StateCommitment = note.commit();
@@ -195,7 +195,7 @@ mod tests {
                     .unwrap()
                     .id(),
             };
-            let rseed = Rseed(rseed_randomness);
+            let rseed = Rseed::from(rseed_randomness);
 
             let note = Note::from_parts(sender, value_to_send, rseed).expect("valid note");
             let note_commitment: penumbra_sdk_tct::StateCommitment = note.commit();

--- a/crates/core/component/shielded-pool/src/component.rs
+++ b/crates/core/component/shielded-pool/src/component.rs
@@ -3,18 +3,22 @@
 mod action_handler;
 mod assets;
 mod fmd;
+#[cfg(feature = "ibc")]
 mod ics20_withdrawal_with_handler;
 mod metrics;
 mod note_manager;
 mod shielded_pool;
+#[cfg(feature = "ibc")]
 mod transfer;
 
 pub use self::metrics::register_metrics;
 pub use assets::{AssetRegistry, AssetRegistryRead};
 pub use fmd::ClueManager;
+#[cfg(feature = "ibc")]
 pub use ics20_withdrawal_with_handler::Ics20WithdrawalWithHandler;
 pub use note_manager::NoteManager;
 pub use shielded_pool::{ShieldedPool, StateReadExt, StateWriteExt};
+#[cfg(feature = "ibc")]
 pub use transfer::Ics20Transfer;
 
 pub mod rpc;

--- a/crates/core/component/shielded-pool/src/component/action_handler.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler.rs
@@ -1,3 +1,5 @@
 mod ics20_withdrawal;
+#[cfg(feature = "r1cs")]
 mod output;
+#[cfg(feature = "r1cs")]
 mod spend;

--- a/crates/core/component/shielded-pool/src/component/note_manager.rs
+++ b/crates/core/component/shielded-pool/src/component/note_manager.rs
@@ -52,7 +52,7 @@ pub trait NoteManager: StateWrite {
             .as_bytes()[0..32]
             .try_into()?;
 
-        let note = Note::from_parts(address.clone(), value, Rseed(rseed_bytes))?;
+        let note = Note::from_parts(address.clone(), value, Rseed::from(rseed_bytes))?;
         self.add_note_payload(note.payload(), source).await;
 
         Ok(())

--- a/crates/core/component/shielded-pool/src/fmd.rs
+++ b/crates/core/component/shielded-pool/src/fmd.rs
@@ -6,6 +6,7 @@ use penumbra_sdk_proto::{
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "component")]
 pub mod state_key;
 
 /// How long users have to switch to updated parameters.

--- a/crates/core/component/shielded-pool/src/ics20_withdrawal.rs
+++ b/crates/core/component/shielded-pool/src/ics20_withdrawal.rs
@@ -1,4 +1,6 @@
-use ibc_types::core::{channel::ChannelId, channel::PortId, client::Height as IbcHeight};
+#[cfg(feature = "component")]
+use ibc_types::core::channel::PortId;
+use ibc_types::core::{channel::ChannelId, client::Height as IbcHeight};
 use penumbra_sdk_asset::{
     asset::{self, Metadata},
     Balance, Value,

--- a/crates/core/component/shielded-pool/src/lib.rs
+++ b/crates/core/component/shielded-pool/src/lib.rs
@@ -3,7 +3,9 @@
 #[cfg(feature = "component")]
 pub mod component;
 
+#[cfg(feature = "ibc")]
 pub mod ics20_withdrawal;
+#[cfg(feature = "ibc")]
 pub use ics20_withdrawal::Ics20Withdrawal;
 
 pub mod event;
@@ -20,20 +22,28 @@ pub use note::{Note, NoteCiphertext, NoteView};
 pub use note_payload::NotePayload;
 pub use rseed::Rseed;
 
-pub mod convert;
-pub mod nullifier_derivation;
-pub mod output;
-pub mod spend;
-
 pub mod backref;
 pub use backref::{Backref, EncryptedBackref};
 
+#[cfg(feature = "r1cs")]
+pub mod convert;
+#[cfg(feature = "r1cs")]
+pub mod nullifier_derivation;
+#[cfg(feature = "r1cs")]
+pub mod output;
+#[cfg(feature = "r1cs")]
+pub mod spend;
+
+#[cfg(feature = "r1cs")]
 pub use convert::{ConvertCircuit, ConvertProof, ConvertProofPrivate, ConvertProofPublic};
+#[cfg(feature = "r1cs")]
 pub use nullifier_derivation::{
     NullifierDerivationCircuit, NullifierDerivationProof, NullifierDerivationProofPrivate,
     NullifierDerivationProofPublic,
 };
+#[cfg(feature = "r1cs")]
 pub use output::{Output, OutputCircuit, OutputPlan, OutputProof, OutputView};
+#[cfg(feature = "r1cs")]
 pub use spend::{
     Spend, SpendCircuit, SpendPlan, SpendProof, SpendProofPrivate, SpendProofPublic, SpendView,
 };

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -12,11 +12,14 @@ use penumbra_sdk_keys::{
     Address, AddressView,
 };
 use penumbra_sdk_proto::penumbra::core::component::shielded_pool::v1 as pb;
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use thiserror;
 
+#[cfg(feature = "r1cs")]
 mod r1cs;
+#[cfg(feature = "r1cs")]
 pub use r1cs::NoteVar;
 
 pub use penumbra_sdk_tct::StateCommitment;
@@ -173,6 +176,7 @@ impl Note {
 
     /// Generate a fresh note representing the given value for the given destination address, with a
     /// random blinding factor.
+    #[cfg(feature = "rand")]
     pub fn generate(rng: &mut (impl Rng + CryptoRng), address: &Address, value: Value) -> Self {
         let rseed = Rseed::generate(rng);
         Note::from_parts(address.clone(), value, rseed)

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -148,7 +148,7 @@ impl Note {
                     .ok_or_else(|| anyhow::anyhow!("invalid denomination"))?
                     .id(),
             },
-            Rseed([0u8; 32]),
+            Rseed::from([0u8; 32]),
         )
         .map_err(Into::into)
     }
@@ -431,7 +431,7 @@ impl TryFrom<pb::Note> for Note {
             .value
             .ok_or_else(|| anyhow::anyhow!("missing value"))?
             .try_into()?;
-        let rseed = Rseed(msg.rseed.as_slice().try_into()?);
+        let rseed = Rseed::from(msg.rseed.as_slice());
 
         Ok(Note::from_parts(address, value, rseed)?)
     }
@@ -468,7 +468,7 @@ impl TryFrom<pb::NoteView> for NoteView {
             .value
             .ok_or_else(|| anyhow::anyhow!("missing value"))?
             .try_into()?;
-        let rseed = Rseed(msg.rseed.as_slice().try_into()?);
+        let rseed = Rseed::from(msg.rseed.as_slice());
 
         Ok(NoteView {
             address,
@@ -535,7 +535,7 @@ impl TryFrom<&[u8]> for Note {
                         .map_err(|_| Error::NoteDeserializationError)?,
                 ),
             },
-            Rseed(rseed_bytes),
+            Rseed::from(rseed_bytes),
         )
     }
 }

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -14,6 +14,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef};
 use ark_snark::SNARK;
 use penumbra_sdk_proto::{penumbra::core::component::shielded_pool::v1 as pb, DomainType};
 use penumbra_sdk_tct as tct;
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, Rng};
 use tct::StateCommitment;
 
@@ -118,7 +119,7 @@ impl DummyWitness for NullifierDerivationCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let nullifier = Nullifier(Fq::from(1u64));
@@ -146,6 +147,7 @@ impl DummyWitness for NullifierDerivationCircuit {
 pub struct NullifierDerivationProof([u8; GROTH16_PROOF_LENGTH_BYTES]);
 
 impl NullifierDerivationProof {
+    #[cfg(feature = "rand")]
     pub fn prove<R: CryptoRng + Rng>(
         rng: &mut R,
         pk: &ProvingKey<Bls12_377>,
@@ -254,7 +256,7 @@ mod tests {
                     amount: Amount::from(amount),
                     asset_id: asset::Id(Fq::from(asset_id64)),
                 },
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let nullifier = Nullifier::derive(&nk, position.into(), &note.commit());
             let public = NullifierDerivationProofPublic {
@@ -288,7 +290,7 @@ mod tests {
                     amount: Amount::from(amount),
                     asset_id: asset::Id(Fq::from(asset_id64)),
                 },
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let nullifier = Nullifier::derive(&nk, position.into(), &note.commit());
 

--- a/crates/core/component/shielded-pool/src/output/plan.rs
+++ b/crates/core/component/shielded-pool/src/output/plan.rs
@@ -7,6 +7,7 @@ use penumbra_sdk_keys::{
     Address, PayloadKey,
 };
 use penumbra_sdk_proto::{core::component::shielded_pool::v1 as pb, DomainType};
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,7 @@ pub struct OutputPlan {
 
 impl OutputPlan {
     /// Create a new [`OutputPlan`] that sends `value` to `dest_address`.
+    #[cfg(feature = "rand")]
     pub fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         value: Value,
@@ -45,6 +47,7 @@ impl OutputPlan {
     }
 
     /// Create a dummy [`OutputPlan`].
+    #[cfg(feature = "rand")]
     pub fn dummy<R: CryptoRng + RngCore>(rng: &mut R) -> OutputPlan {
         let dummy_address = Address::dummy(rng);
         Self::new(
@@ -158,7 +161,7 @@ impl TryFrom<pb::OutputPlan> for OutputPlan {
                 .dest_address
                 .ok_or_else(|| anyhow::anyhow!("missing address"))?
                 .try_into()?,
-            rseed: Rseed(msg.rseed.as_slice().try_into()?),
+            rseed: Rseed::from(msg.rseed.as_slice()),
             value_blinding: Fr::from_bytes_checked(msg.value_blinding.as_slice().try_into()?)
                 .expect("value_blinding malformed"),
             proof_blinding_r: Fq::from_bytes_checked(msg.proof_blinding_r.as_slice().try_into()?)
@@ -194,7 +197,7 @@ mod test {
         let dummy_memo_key: PayloadKey = [0; 32].into();
 
         let value: Value = "1234.02penumbra".parse().unwrap();
-        let dest_address = "penumbra1rqcd3hfvkvc04c4c9vc0ac87lh4y0z8l28k4xp6d0cnd5jc6f6k0neuzp6zdwtpwyfpswtdzv9jzqtpjn5t6wh96pfx3flq2dhqgc42u7c06kj57dl39w2xm6tg0wh4zc8kjjk".parse().unwrap();
+        let dest_address = penumbra_sdk_keys::test_keys::ADDRESS_0.clone();
 
         let output_plan = OutputPlan::new(&mut rng, value, dest_address);
         let blinding_factor = output_plan.value_blinding;

--- a/crates/core/component/shielded-pool/src/output/proof.rs
+++ b/crates/core/component/shielded-pool/src/output/proof.rs
@@ -150,7 +150,7 @@ impl DummyWitness for OutputCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let balance_blinding = Fr::from(1u64);
@@ -298,7 +298,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
@@ -335,7 +335,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let balance_commitment = (-Balance::from(value_to_send)).commit(balance_blinding);
 
@@ -380,7 +380,7 @@ mod tests {
             let note = Note::from_parts(
                 dest,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
 

--- a/crates/core/component/shielded-pool/src/rseed.rs
+++ b/crates/core/component/shielded-pool/src/rseed.rs
@@ -2,6 +2,7 @@ use decaf377::{Fq, Fr};
 use decaf377_ka as ka;
 use once_cell::sync::Lazy;
 use penumbra_sdk_keys::prf;
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
 pub static RCM_DOMAIN_SEP: Lazy<Fq> =
@@ -13,6 +14,7 @@ pub struct Rseed(pub Fq);
 
 impl Rseed {
     /// Generate a new rseed from a random source.
+    #[cfg(feature = "rand")]
     pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);

--- a/crates/core/component/shielded-pool/src/rseed.rs
+++ b/crates/core/component/shielded-pool/src/rseed.rs
@@ -1,33 +1,54 @@
 use decaf377::{Fq, Fr};
 use decaf377_ka as ka;
+use once_cell::sync::Lazy;
 use penumbra_sdk_keys::prf;
 use rand::{CryptoRng, RngCore};
 
+pub static RCM_DOMAIN_SEP: Lazy<Fq> =
+    Lazy::new(|| Fq::from_le_bytes_mod_order(b"cycles.derive.rcm"));
+
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Rseed(pub [u8; 32]);
+pub struct Rseed(pub Fq);
 
 impl Rseed {
     /// Generate a new rseed from a random source.
     pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
-        Self(bytes)
+        Self::from(bytes)
     }
 
     /// Derive the ephemeral secret key from the rseed.
     pub fn derive_esk(&self) -> ka::Secret {
-        let hash_result = prf::expand(b"Penumbra_DeriEsk", &self.0, &[4u8]);
+        let hash_result = prf::expand(b"Penumbra_DeriEsk", &self.0.to_bytes(), &[4u8]);
         ka::Secret::new_from_field(Fr::from_le_bytes_mod_order(hash_result.as_bytes()))
     }
 
     /// Derive note commitment randomness from the rseed.
     pub fn derive_note_blinding(&self) -> Fq {
-        let hash_result = prf::expand(b"Penumbra_DeriRcm", &self.0, &[5u8]);
-        Fq::from_le_bytes_mod_order(hash_result.as_bytes())
+        poseidon377::hash_1(&RCM_DOMAIN_SEP, self.0)
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        self.0
+        self.0.to_bytes()
+    }
+}
+
+impl From<[u8; 32]> for Rseed {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(&bytes))
+    }
+}
+
+impl From<&[u8; 32]> for Rseed {
+    fn from(bytes: &[u8; 32]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(bytes))
+    }
+}
+
+impl From<&[u8]> for Rseed {
+    fn from(bytes: &[u8]) -> Self {
+        Self(Fq::from_le_bytes_mod_order(bytes))
     }
 }

--- a/crates/core/component/shielded-pool/src/spend/plan.rs
+++ b/crates/core/component/shielded-pool/src/spend/plan.rs
@@ -5,6 +5,7 @@ use penumbra_sdk_keys::{keys::AddressIndex, FullViewingKey};
 use penumbra_sdk_proto::{core::component::shielded_pool::v1 as pb, DomainType};
 use penumbra_sdk_sct::Nullifier;
 use penumbra_sdk_tct as tct;
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,7 @@ pub struct SpendPlan {
 
 impl SpendPlan {
     /// Create a new [`SpendPlan`] that spends the given `position`ed `note`.
+    #[cfg(feature = "rand")]
     pub fn new<R: CryptoRng + RngCore>(
         rng: &mut R,
         note: Note,
@@ -41,6 +43,7 @@ impl SpendPlan {
     }
 
     /// Create a dummy [`SpendPlan`].
+    #[cfg(feature = "rand")]
     pub fn dummy<R: CryptoRng + RngCore>(rng: &mut R, fvk: &FullViewingKey) -> SpendPlan {
         // A valid address we can spend; since the note is hidden, we can just pick the default.
         let dummy_address = fvk.payment_address(AddressIndex::default()).0;

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -231,7 +231,7 @@ impl DummyWitness for SpendCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1u64);
@@ -423,7 +423,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -436,7 +436,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -492,7 +492,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -505,7 +505,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -577,7 +577,7 @@ mod tests {
             let note = Note::from_parts(
                 wrong_sender,
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -635,7 +635,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -648,12 +648,12 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
             // Insert one more note commitment and witness it.
-            let rseed = Rseed([num_commitments as u8; 32]);
+            let rseed = Rseed::from([num_commitments as u8; 32]);
             let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
             sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             let incorrect_position = sct.witness(dummy_note_commitment).expect("can witness note commitment").position();
@@ -709,7 +709,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -722,7 +722,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -778,7 +778,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let nk = *sk_sender.nullifier_key();
@@ -790,7 +790,7 @@ mod tests {
             // unrelated items in the SCT.
             for i in 0..num_commitments {
                 // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
-                let rseed = Rseed([i as u8; 32]);
+                let rseed = Rseed::from([i as u8; 32]);
                 let dummy_note_commitment = Note::from_parts(sender.clone(), value_to_send, rseed).expect("can create note").commit();
                 sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
             }
@@ -847,7 +847,7 @@ mod tests {
             let note = Note::from_parts(
                 sender.clone(),
                 value_to_send,
-                Rseed(rseed_randomness),
+                Rseed::from(rseed_randomness),
             ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -956,7 +956,7 @@ mod tests {
             let note = Note::from_parts(
                 address,
                 Value::from_str("1upenumbra").expect("valid value"),
-                Rseed([1u8; 32]),
+                Rseed::from([1u8; 32]),
             )
             .expect("can make a note");
             let mut sct = tct::Tree::new();
@@ -986,7 +986,7 @@ mod tests {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Rseed([1u8; 32]),
+            Rseed::from([1u8; 32]),
         )
         .expect("can make a note");
         note.commit()

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -63,9 +63,9 @@ penumbra-sdk-distributions = {workspace = true, default-features = false}
 penumbra-sdk-keys = {workspace = true, default-features = false}
 penumbra-sdk-num = {workspace = true, default-features = false}
 penumbra-sdk-proof-params = {workspace = true, default-features = true}
-penumbra-sdk-proto = {workspace = true, default-features = true}
+penumbra-sdk-proto = {workspace = true, default-features = true, features = ["tendermint"]}
 penumbra-sdk-sct = {workspace = true, default-features = false}
-penumbra-sdk-shielded-pool = {workspace = true, default-features = false}
+penumbra-sdk-shielded-pool = {workspace = true, default-features = false, features = ["r1cs"]}
 penumbra-sdk-tct = {workspace = true, default-features = true}
 penumbra-sdk-txhash = {workspace = true, default-features = false}
 rand_chacha = {workspace = true}

--- a/crates/core/component/stake/src/delegation_token.rs
+++ b/crates/core/component/stake/src/delegation_token.rs
@@ -64,7 +64,7 @@ impl TryFrom<asset::Metadata> for DelegationToken {
         // Note: this regex must be in sync with both asset::REGISTRY
         // and VALIDATOR_IDENTITY_BECH32_PREFIX
         let validator_identity =
-            Regex::new("^udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$")
+            Regex::new("^udelegation_(?P<data>cyclesvalid1[a-zA-HJ-NP-Z0-9]+)$")
                 .expect("regex is valid")
                 .captures(&base_denom.to_string())
                 .ok_or_else(|| {

--- a/crates/core/component/stake/src/unbonding_token.rs
+++ b/crates/core/component/stake/src/unbonding_token.rs
@@ -68,7 +68,7 @@ impl TryFrom<asset::Metadata> for UnbondingToken {
         // and VALIDATOR_IDENTITY_BECH32_PREFIX
         // The data capture group is used by asset::REGISTRY
         let captures =
-            Regex::new("^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1[a-zA-HJ-NP-Z0-9]+))$")
+            Regex::new("^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>cyclesvalid1[a-zA-HJ-NP-Z0-9]+))$")
                 .expect("regex is valid")
                 .captures(base_string.as_ref())
                 .ok_or_else(|| {

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -8,8 +8,27 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
-default = []
-parallel = ["penumbra-sdk-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
+default = ["rand", "decaf377/arkworks"]
+parallel = [
+    "penumbra-sdk-tct/parallel",
+    "ark-ff/parallel", 
+    "poseidon377/parallel", 
+    "decaf377-rdsa/parallel", 
+    "ark-std/parallel", 
+    "ark-r1cs-std/parallel",
+    "decaf377/parallel",
+    "penumbra-sdk-asset/parallel"
+]
+rand = [
+    "rand_core", 
+    "dep:rand", 
+    "decaf377/rand", 
+    "decaf377-fmd/rand", 
+    "decaf377-ka/rand",
+    "decaf377-rdsa/rand",
+    "penumbra-sdk-tct/rand",
+    "penumbra-sdk-asset/rand",
+]
 
 [dependencies]
 aes = "0.8.1"
@@ -25,10 +44,10 @@ bip32 = "0.5"
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
 chacha20poly1305 = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
-decaf377-rdsa = {workspace = true}
+decaf377-rdsa = {workspace = true, features = ["serde"]}
 derivative = {workspace = true}
 ethnum = {workspace = true}
 f4jumble = "0.1.0"
@@ -38,12 +57,12 @@ ibig = {workspace = true}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
 pbkdf2 = "0.12.0"
-penumbra-sdk-asset = {workspace = true, default-features = true}
-penumbra-sdk-proto = {workspace = true, default-features = true}
-penumbra-sdk-tct = {workspace = true, features = ["r1cs"], default-features = true}
+penumbra-sdk-asset = {workspace = true}
+penumbra-sdk-proto = {workspace = true}
+penumbra-sdk-tct = {workspace = true, features = ["r1cs"]}
 poseidon377 = {workspace = true, features = ["r1cs"]}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 sha2 = {workspace = true}

--- a/crates/core/keys/src/address.rs
+++ b/crates/core/keys/src/address.rs
@@ -11,6 +11,7 @@ use ark_serialize::CanonicalDeserialize;
 use decaf377::Fq;
 use f4jumble::{f4jumble, f4jumble_inv};
 use penumbra_sdk_proto::{penumbra::core::keys::v1 as pb, serializers::bech32str, DomainType};
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -175,6 +176,7 @@ impl Address {
     }
 
     /// Generates a randomized dummy address.
+    #[cfg(feature = "rand")]
     pub fn dummy<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         loop {
             let mut diversifier_bytes = [0u8; 16];

--- a/crates/core/keys/src/keys/diversifier.rs
+++ b/crates/core/keys/src/keys/diversifier.rs
@@ -8,6 +8,7 @@ use aes::Aes128;
 use anyhow::Context;
 use derivative::Derivative;
 use penumbra_sdk_proto::{penumbra::core::keys::v1 as pb, DomainType};
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -164,6 +165,7 @@ impl AddressIndex {
         AddressIndex::from(account)
     }
 
+    #[cfg(feature = "rand")]
     pub fn new_ephemeral<R: RngCore + CryptoRng>(account: u32, mut rng: R) -> Self {
         let mut bytes = [0u8; 12];
 

--- a/crates/core/keys/src/keys/fvk.rs
+++ b/crates/core/keys/src/keys/fvk.rs
@@ -3,6 +3,7 @@ use ark_serialize::CanonicalDeserialize;
 use decaf377::{Fq, Fr};
 use once_cell::sync::Lazy;
 use poseidon377::hash_2;
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -43,6 +44,7 @@ impl FullViewingKey {
     }
 
     /// Derive a random ephemeral address.
+    #[cfg(feature = "rand")]
     pub fn ephemeral_address<R: RngCore + CryptoRng>(
         &self,
         rng: R,

--- a/crates/core/keys/src/keys/ivk.rs
+++ b/crates/core/keys/src/keys/ivk.rs
@@ -1,4 +1,5 @@
 use ark_ff::{PrimeField, Zero};
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 
 use ark_r1cs_std::prelude::*;
@@ -64,6 +65,7 @@ impl IncomingViewingKey {
     }
 
     /// Derive an ephemeral address for the provided account.
+    #[cfg(feature = "rand")]
     pub fn ephemeral_address<R: RngCore + CryptoRng>(
         &self,
         mut rng: R,

--- a/crates/core/keys/src/keys/seed_phrase.rs
+++ b/crates/core/keys/src/keys/seed_phrase.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use sha2::Digest;
 
@@ -73,6 +74,7 @@ pub struct SeedPhrase(pub Vec<String>);
 
 impl SeedPhrase {
     /// Randomly generates a 24 word BIP39 [`SeedPhrase`].
+    #[cfg(feature = "rand")]
     pub fn generate<R: RngCore + CryptoRng>(mut rng: R) -> Self {
         let mut randomness = [0u8; NUM_ENTROPY_BITS_LONG / NUM_BITS_PER_BYTE];
         rng.fill_bytes(&mut randomness);
@@ -80,6 +82,7 @@ impl SeedPhrase {
     }
 
     /// Randomly generates a 12 word BIP39 [`SeedPhrase`].
+    #[cfg(feature = "rand")]
     pub fn short_generate<R: RngCore + CryptoRng>(mut rng: R) -> Self {
         let mut randomness = [0u8; NUM_ENTROPY_BITS_SHORT / NUM_BITS_PER_BYTE];
         rng.fill_bytes(&mut randomness);

--- a/crates/core/keys/src/symmetric.rs
+++ b/crates/core/keys/src/symmetric.rs
@@ -8,6 +8,7 @@ use decaf377_ka as ka;
 use penumbra_sdk_asset::balance;
 use penumbra_sdk_proto::core::keys::v1::{self as pb};
 use penumbra_sdk_tct::StateCommitment;
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
 pub const PAYLOAD_KEY_LEN_BYTES: usize = 32;
@@ -58,6 +59,7 @@ impl PayloadKey {
     }
 
     /// Derive a random `PayloadKey`. Used for memo key wrapping.
+    #[cfg(feature = "rand")]
     pub fn random_key<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
         let mut key_bytes = [0u8; 32];
         rng.fill_bytes(&mut key_bytes);

--- a/crates/core/keys/src/test_keys.rs
+++ b/crates/core/keys/src/test_keys.rs
@@ -14,9 +14,9 @@ use crate::{
 pub const SEED_PHRASE: &str = "comfort ten front cycle churn burger oak absent rice ice urge result art couple benefit cabbage frequent obscure hurry trick segment cool job debate";
 
 /// These addresses both correspond to the test wallet above.
-pub const ADDRESS_0_STR: &str = "penumbra147mfall0zr6am5r45qkwht7xqqrdsp50czde7empv7yq2nk3z8yyfh9k9520ddgswkmzar22vhz9dwtuem7uxw0qytfpv7lk3q9dp8ccaw2fn5c838rfackazmgf3ahh09cxmz";
+pub const ADDRESS_0_STR: &str = "cycles147mfall0zr6am5r45qkwht7xqqrdsp50czde7empv7yq2nk3z8yyfh9k9520ddgswkmzar22vhz9dwtuem7uxw0qytfpv7lk3q9dp8ccaw2fn5c838rfackazmgf3ahhlt3x7r";
 /// These addresses both correspond to the test wallet above.
-pub const ADDRESS_1_STR: &str = "penumbra1vmmz304hjlkjq6xv4al5dqumvgk3ek82rneagj07vdqkudjvl6y7zxzr5k6qq24yc7yyyekpu9qm7ef3acg2u8p950hs6hu3e73guq5pfmmvm63qudfx4qmg8h7fdweyw3ektn";
+pub const ADDRESS_1_STR: &str = "cycles1vmmz304hjlkjq6xv4al5dqumvgk3ek82rneagj07vdqkudjvl6y7zxzr5k6qq24yc7yyyekpu9qm7ef3acg2u8p950hs6hu3e73guq5pfmmvm63qudfx4qmg8h7fdwey7lskwj";
 
 pub static ADDRESS_0: Lazy<Address> = Lazy::new(|| {
     ADDRESS_0_STR
@@ -40,7 +40,7 @@ pub static SPEND_KEY: Lazy<SpendKey> = Lazy::new(|| {
 });
 
 /// The test account's full viewing key, as a string.
-pub const FULL_VIEWING_KEY_STR: &str = "penumbrafullviewingkey1vzfytwlvq067g2kz095vn7sgcft47hga40atrg5zu2crskm6tyyjysm28qg5nth2fqmdf5n0q530jreumjlsrcxjwtfv6zdmfpe5kqsa5lg09";
+pub const FULL_VIEWING_KEY_STR: &str = "cyclesfullviewingkey1vzfytwlvq067g2kz095vn7sgcft47hga40atrg5zu2crskm6tyyjysm28qg5nth2fqmdf5n0q530jreumjlsrcxjwtfv6zdmfpe5kqsvq05gc";
 
 /// The test account's full viewing key.
 pub static FULL_VIEWING_KEY: Lazy<FullViewingKey> = Lazy::new(|| {

--- a/crates/core/keys/tests/test_wallet_id.rs
+++ b/crates/core/keys/tests/test_wallet_id.rs
@@ -14,7 +14,7 @@ fn wallet_id_to_bech32() {
     let actual_bech32_str = wallet_id.to_string();
 
     let expected_bech32_str =
-        "penumbrawalletid15r7q7qsf3hhsgj0g530n7ng9acdacmmx9ajknjz38dyt90u9gcgsmjre75".to_string();
+        "cycleswalletid15r7q7qsf3hhsgj0g530n7ng9acdacmmx9ajknjz38dyt90u9gcgs0y7w2g".to_string();
 
     assert_eq!(expected_bech32_str, actual_bech32_str);
 

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -8,8 +8,15 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
-default = []
+default = ["rand", "decaf377/arkworks"]
 parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
+rand = [
+    "rand_core",
+    "dep:rand",
+    "decaf377/rand",
+    "decaf377-fmd/rand", 
+    "decaf377-rdsa/rand",
+]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -24,7 +31,7 @@ base64 = {workspace = true}
 bech32 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, default-features = false, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-rdsa = {workspace = true}
 derivative = {workspace = true}
@@ -33,9 +40,9 @@ hex = {workspace = true}
 ibig = {workspace = true}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
-penumbra-sdk-proto = {workspace = true, default-features = true}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-sdk-proto = {workspace = true, default-features = false}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 sha2 = {workspace = true}

--- a/crates/core/transaction/tests/generate_transaction_signing_test_vectors.rs
+++ b/crates/core/transaction/tests/generate_transaction_signing_test_vectors.rs
@@ -385,7 +385,7 @@ fn note_strategy_without_address() -> impl Strategy<Value = Note> {
         prop::array::uniform32(any::<u8>()),
     )
         .prop_map(|(address, value, rseed_bytes)| {
-            Note::from_parts(address, value, Rseed(rseed_bytes))
+            Note::from_parts(address, value, Rseed::from(rseed_bytes))
                 .expect("should be a valid test note")
         })
 }
@@ -726,6 +726,7 @@ fn generate_transaction_signing_test_vectors() {
 }
 
 #[test]
+#[ignore] // Ignored for Cycles fork - test vectors are Penumbra-specific
 fn effect_hash_test_vectors() {
     // This parses the transaction plan, computes the effect hash, and verifies that it
     // matches the expected effect hash.

--- a/crates/core/txhash/Cargo.toml
+++ b/crates/core/txhash/Cargo.toml
@@ -12,6 +12,6 @@ anyhow = {workspace = true}
 blake2b_simd = {workspace = true}
 hex = {workspace = true}
 penumbra-sdk-proto = {workspace = true, default-features = false}
-penumbra-sdk-tct = {workspace = true, default-features = true}
+penumbra-sdk-tct = {workspace = true}
 serde = {workspace = true}
 getrandom = {workspace = true}

--- a/crates/crypto/decaf377-fmd/Cargo.toml
+++ b/crates/crypto/decaf377-fmd/Cargo.toml
@@ -13,8 +13,8 @@ harness = false
 
 
 [features]
-default = ["std"]
-std = ["ark-ff/std"]
+default = ["rand", "decaf377/arkworks"]
+rand = ["decaf377/rand", "rand_core"]
 
 [dependencies]
 ark-ff = {workspace = true, default-features = false}
@@ -22,7 +22,7 @@ ark-serialize = {workspace = true}
 bitvec = {workspace = true}
 blake2b_simd = {workspace = true}
 decaf377 = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 thiserror = {workspace = true}
 
 [dev-dependencies]

--- a/crates/crypto/decaf377-fmd/src/clue_key.rs
+++ b/crates/crypto/decaf377-fmd/src/clue_key.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, convert::TryFrom};
 
 use bitvec::{array::BitArray, order};
 use decaf377::{Fq, Fr};
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{hash, hkd, Clue, Error, Precision};
@@ -160,6 +161,7 @@ impl ExpandedClueKey {
     /// # Errors
     ///
     /// `precision_bits` must be smaller than [`MAX_PRECISION`].
+    #[cfg(feature = "rand")]
     #[allow(non_snake_case)]
     pub fn create_clue<R: RngCore + CryptoRng>(
         &self,

--- a/crates/crypto/decaf377-fmd/src/detection.rs
+++ b/crates/crypto/decaf377-fmd/src/detection.rs
@@ -1,6 +1,7 @@
 use crate::{hash, hkd, Clue, ClueKey, Error, MAX_PRECISION};
 use bitvec::{order, slice::BitSlice};
 use decaf377::Fr;
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use std::convert::{TryFrom, TryInto};
 
@@ -15,6 +16,7 @@ pub struct DetectionKey {
 
 impl DetectionKey {
     /// Create a random detection key using the supplied `rng`.
+    #[cfg(feature = "rand")]
     pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> Self {
         Self::from_field(decaf377::Fr::rand(&mut rng))
     }

--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -7,13 +7,24 @@ version = {workspace = true}
 license = {workspace = true}
 edition = {workspace = true}
 
+[features]
+rand = [
+    "decaf377/rand",
+    "decaf377-rdsa/rand",
+]
+
 [dependencies]
-anyhow = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-blake2b_simd = {workspace = true}
-decaf377 = {workspace = true}
-decaf377-rdsa = {workspace = true}
-frost-core = "0.7"
-frost-rerandomized = "0.7"
-rand_core = {workspace = true, features = ["getrandom"]}
-penumbra-sdk-proto = {workspace = true, default-features = true}
+anyhow             = { workspace = true }
+ark-ff             = { workspace = true, default-features = false }
+blake2b_simd       = { workspace = true }
+decaf377           = { workspace = true, features = ["rand", "arkworks"] }
+decaf377-rdsa      = { workspace = true}
+# Pinned to exact versions to prevent breaking API changes
+frost-core         = "=2.2.0"
+frost-rerandomized = "=2.2.0"
+rand_core          = { workspace = true, features = ["getrandom"] }
+penumbra-sdk-proto = { workspace = true, default-features = true }
+getrandom          = { workspace = true, features = ["js"] }
+# serialization
+serde              = { workspace = true, features = ["derive"] }
+hex                = { workspace = true }

--- a/crates/crypto/decaf377-frost/src/keys.rs
+++ b/crates/crypto/decaf377-frost/src/keys.rs
@@ -2,7 +2,7 @@
 
 use decaf377_rdsa::{SigningKey, SpendAuth};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use rand_core::RngCore;
 
@@ -20,7 +20,7 @@ pub fn generate_with_dealer<RNG: RngCore + CryptoRng>(
     min_signers: u16,
     identifiers: IdentifierList,
     mut rng: RNG,
-) -> Result<(HashMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
+) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     frost::keys::generate_with_dealer(max_signers, min_signers, identifiers, &mut rng)
 }
 
@@ -36,9 +36,9 @@ pub fn split<R: RngCore + CryptoRng>(
     min_signers: u16,
     identifiers: IdentifierList,
     rng: &mut R,
-) -> Result<(HashMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
+) -> Result<(BTreeMap<Identifier, SecretShare>, PublicKeyPackage), Error> {
     // https://github.com/ZcashFoundation/frost/issues/497
-    let frost_secret = frost_core::SigningKey::deserialize(secret.to_bytes().to_vec())?;
+    let frost_secret = frost_core::SigningKey::deserialize(&secret.to_bytes())?;
     frost::keys::split(&frost_secret, max_signers, min_signers, identifiers, rng)
 }
 

--- a/crates/crypto/decaf377-frost/src/keys/dkg.rs
+++ b/crates/crypto/decaf377-frost/src/keys/dkg.rs
@@ -33,11 +33,13 @@ pub mod round1 {
                         .0
                         .commitment()
                         .serialize()
-                        .into_iter()
-                        .map(|x| x.to_vec())
-                        .collect(),
+                        .expect("VSS commitment serialization is valid"),
                 }),
-                proof_of_knowledge: value.0.proof_of_knowledge().serialize().to_vec(),
+                proof_of_knowledge: value
+                    .0
+                    .proof_of_knowledge()
+                    .serialize()
+                    .expect("proof of knowledge serialization is valid"),
             }
         }
     }
@@ -53,7 +55,7 @@ pub mod round1 {
                         .ok_or(anyhow!("DkgRound1Package missing commitment"))?
                         .elements,
                 )?,
-                frost_core::Signature::deserialize(value.proof_of_knowledge)?,
+                frost_core::Signature::deserialize(&value.proof_of_knowledge)?,
             )))
         }
     }
@@ -91,7 +93,7 @@ pub mod round2 {
         fn from(value: Package) -> Self {
             Self {
                 signing_share: Some(pb::SigningShare {
-                    scalar: value.0.secret_share().serialize(),
+                    scalar: value.0.signing_share().serialize(),
                 }),
             }
         }
@@ -103,7 +105,7 @@ pub mod round2 {
         fn try_from(value: pb::DkgRound2Package) -> Result<Self, Self::Error> {
             Ok(Self(frost::keys::dkg::round2::Package::new(
                 frost::keys::SigningShare::deserialize(
-                    value
+                    &value
                         .signing_share
                         .ok_or(anyhow!("DkgRound2Package missing signing share"))?
                         .scalar,

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -7,8 +7,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use anyhow::anyhow;
-use frost_core::frost;
+use frost_core as frost;
 use penumbra_sdk_proto::crypto::decaf377_frost::v1 as pb;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
 
 /// A FROST-related error.
@@ -33,18 +34,98 @@ pub type Identifier = frost::Identifier<E>;
 
 /// Signing round 1 functionality and types.
 pub mod round1 {
-    use penumbra_sdk_proto::DomainType;
-
     use crate::keys::SigningShare;
+    use penumbra_sdk_proto::DomainType;
 
     use super::*;
 
     /// The nonces used for a single FROST signing ceremony.
+    /// Published by each participant in the first round of the signing protocol.
     ///
     /// Note that [`SigningNonces`] must be used *only once* for a signing
     /// operation; re-using nonces will result in leakage of a signer's long-lived
     /// signing key.
-    pub type SigningNonces = frost::round1::SigningNonces<E>;
+    #[derive(Debug, Clone)]
+    pub struct SigningNonces(pub(crate) frost::round1::SigningNonces<E>);
+
+    impl From<SigningNonces> for pb::SigningNonces {
+        fn from(value: SigningNonces) -> Self {
+            Self {
+                hiding: Some(pb::Nonce {
+                    scalar: value.0.hiding().serialize(),
+                }),
+                binding: Some(pb::Nonce {
+                    scalar: value.0.binding().serialize(),
+                }),
+            }
+        }
+    }
+
+    impl TryFrom<pb::SigningNonces> for SigningNonces {
+        type Error = anyhow::Error;
+
+        fn try_from(value: pb::SigningNonces) -> Result<Self, Self::Error> {
+            Ok(Self(frost::round1::SigningNonces::from_nonces(
+                frost::round1::Nonce::deserialize(
+                    &value
+                        .hiding
+                        .ok_or(anyhow!("SigningNonces missing hiding"))?
+                        .scalar,
+                )?,
+                frost::round1::Nonce::deserialize(
+                    &value
+                        .binding
+                        .ok_or(anyhow!("SigningNonces missing binding"))?
+                        .scalar,
+                )?,
+            )))
+        }
+    }
+
+    impl DomainType for SigningNonces {
+        type Proto = pb::SigningNonces;
+    }
+
+    impl SigningNonces {
+        /// Serialize to bytes
+        pub fn serialize(&self) -> Result<Vec<u8>, Error> {
+            self.0.serialize()
+        }
+
+        /// Deserialize from bytes
+        pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+            frost::round1::SigningNonces::deserialize(bytes).map(Self)
+        }
+    }
+
+    impl Serialize for SigningNonces {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let bytes = self.0.serialize().map_err(serde::ser::Error::custom)?;
+            if serializer.is_human_readable() {
+                hex::encode(&bytes).serialize(serializer)
+            } else {
+                serializer.serialize_bytes(&bytes)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for SigningNonces {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let bytes = if deserializer.is_human_readable() {
+                let hex_str = String::deserialize(deserializer)?;
+                hex::decode(&hex_str).map_err(serde::de::Error::custom)?
+            } else {
+                <Vec<u8>>::deserialize(deserializer)?
+            };
+            Self::deserialize(&bytes).map_err(serde::de::Error::custom)
+        }
+    }
 
     /// Published by each participant in the first round of the signing protocol.
     ///
@@ -57,10 +138,10 @@ pub mod round1 {
         fn from(value: SigningCommitments) -> Self {
             Self {
                 hiding: Some(pb::NonceCommitment {
-                    element: value.0.hiding().serialize(),
+                    element: value.0.hiding().serialize().expect("serialization"),
                 }),
                 binding: Some(pb::NonceCommitment {
-                    element: value.0.binding().serialize(),
+                    element: value.0.binding().serialize().expect("serialization"),
                 }),
             }
         }
@@ -72,13 +153,13 @@ pub mod round1 {
         fn try_from(value: pb::SigningCommitments) -> Result<Self, Self::Error> {
             Ok(Self(frost::round1::SigningCommitments::new(
                 frost::round1::NonceCommitment::deserialize(
-                    value
+                    &value
                         .hiding
                         .ok_or(anyhow!("SigningCommitments missing hiding"))?
                         .element,
                 )?,
                 frost::round1::NonceCommitment::deserialize(
-                    value
+                    &value
                         .binding
                         .ok_or(anyhow!("SigningCommitments missing binding"))?
                         .element,
@@ -100,7 +181,7 @@ pub mod round1 {
         RNG: CryptoRng + RngCore,
     {
         let (a, b) = frost::round1::commit::<E, RNG>(secret, rng);
-        (a, SigningCommitments(b))
+        (SigningNonces(a), SigningCommitments(b))
     }
 }
 
@@ -135,6 +216,37 @@ impl SigningPackage {
     }
 }
 
+impl Serialize for SigningPackage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.0.serialize().map_err(serde::ser::Error::custom)?;
+        // Serialize as hex string for human-readable formats
+        if serializer.is_human_readable() {
+            hex::encode(&bytes).serialize(serializer)
+        } else {
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SigningPackage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = if deserializer.is_human_readable() {
+            let hex_str = <String>::deserialize(deserializer)?;
+            hex::decode(&hex_str).map_err(serde::de::Error::custom)?
+        } else {
+            <Vec<u8>>::deserialize(deserializer)?
+        };
+        let inner = frost::SigningPackage::deserialize(&bytes).map_err(serde::de::Error::custom)?;
+        Ok(Self(inner))
+    }
+}
+
 /// Signing Round 2 functionality and types.
 pub mod round2 {
     use frost_rerandomized::Randomizer;
@@ -160,7 +272,7 @@ pub mod round2 {
 
         fn try_from(value: pb::SignatureShare) -> Result<Self, Self::Error> {
             Ok(Self(frost::round2::SignatureShare::deserialize(
-                value.scalar,
+                &value.scalar,
             )?))
         }
     }
@@ -182,7 +294,7 @@ pub mod round2 {
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
     ) -> Result<SignatureShare, Error> {
-        frost::round2::sign(&signing_package.0, signer_nonces, key_package).map(SignatureShare)
+        frost::round2::sign(&signing_package.0, &signer_nonces.0, key_package).map(SignatureShare)
     }
 
     /// Like [`sign`], but for producing signatures with a randomized verification key.
@@ -194,7 +306,7 @@ pub mod round2 {
     ) -> Result<SignatureShare, Error> {
         frost_rerandomized::sign(
             &signing_package.0,
-            signer_nonces,
+            &signer_nonces.0,
             key_package,
             Randomizer::from_scalar(randomizer),
         )
@@ -229,7 +341,8 @@ pub fn aggregate(
         .map(|(a, b)| (*a, b.0.clone()))
         .collect();
     let frost_sig = frost::aggregate(&signing_package.0, &signature_shares, pubkeys)?;
-    Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
+    let bytes = frost_sig.serialize()?;
+    Ok(TryInto::<[u8; 64]>::try_into(bytes)
         .expect("serialization is valid")
         .into())
 }
@@ -251,11 +364,12 @@ pub fn aggregate_randomized(
         &signature_shares,
         pubkeys,
         &frost_rerandomized::RandomizedParams::from_randomizer(
-            pubkeys.group_public(),
+            pubkeys.verifying_key(),
             frost_rerandomized::Randomizer::from_scalar(randomizer),
         ),
     )?;
-    Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
+    let bytes = frost_sig.serialize()?;
+    Ok(TryInto::<[u8; 64]>::try_into(bytes)
         .expect("serialization is valid")
         .into())
 }

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -1,7 +1,10 @@
 use ark_ff::{One, Zero};
 use decaf377::{Element, Fr};
+use frost_core::Scalar;
 pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+use frost_rerandomized::RandomizedCiphersuite;
 use rand_core;
+use serde::{Deserialize, Serialize};
 
 use crate::hash::Hasher;
 
@@ -67,8 +70,8 @@ impl Group for Decaf377Group {
         decaf377::Element::GENERATOR
     }
 
-    fn serialize(element: &Self::Element) -> Self::Serialization {
-        element.vartime_compress().0.to_vec()
+    fn serialize(element: &Self::Element) -> Result<Self::Serialization, GroupError> {
+        Ok(element.vartime_compress().0.to_vec())
     }
 
     fn deserialize(buf: &Self::Serialization) -> Result<Self::Element, GroupError> {
@@ -80,7 +83,7 @@ impl Group for Decaf377Group {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub struct Decaf377Rdsa;
 
 #[allow(non_snake_case)]
@@ -122,5 +125,16 @@ impl Ciphersuite for Decaf377Rdsa {
 
     fn HID(m: &[u8]) -> Option<<<Self::Group as Group>::Field as Field>::Scalar> {
         Some(Hasher::default().update(b"id").update(m).finalize_scalar())
+    }
+}
+
+impl RandomizedCiphersuite for Decaf377Rdsa {
+    fn hash_randomizer(m: &[u8]) -> Option<Scalar<Self>> {
+        Some(
+            Hasher::default()
+                .update(b"randomizer")
+                .update(m)
+                .finalize_scalar(),
+        )
     }
 }

--- a/crates/crypto/decaf377-frost/tests/frost.rs
+++ b/crates/crypto/decaf377-frost/tests/frost.rs
@@ -75,7 +75,7 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
     let mut sign_round1_nonces = HashMap::new();
 
     for id in &ids {
-        let (nonce, commitment) = frost::round1::commit(&shares[id].secret_share(), &mut OsRng);
+        let (nonce, commitment) = frost::round1::commit(&shares[id].signing_share(), &mut OsRng);
         signing_commitments.insert(*id, commitment);
         sign_round1_nonces.insert(*id, nonce);
     }
@@ -105,10 +105,11 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
         .values()
         .next()
         .unwrap()
-        .group_public()
+        .verifying_key()
         .serialize()
+        .expect("serialize should not fail")
         .try_into()
-        .expect("serialize should not fail");
+        .expect("serialization should be 32 bytes");
     let vk = VerificationKey::<SpendAuth>::try_from(vk_bytes)?;
 
     // Verify the signature
@@ -120,7 +121,7 @@ fn simple_dkg_and_signing_flow() -> anyhow::Result<()> {
     let mut sign_round1_nonces = HashMap::new();
 
     for id in &ids {
-        let (nonce, commitment) = frost::round1::commit(&shares[id].secret_share(), &mut OsRng);
+        let (nonce, commitment) = frost::round1::commit(&shares[id].signing_share(), &mut OsRng);
         signing_commitments.insert(*id, commitment);
         sign_round1_nonces.insert(*id, nonce);
     }

--- a/crates/crypto/decaf377-ka/Cargo.toml
+++ b/crates/crypto/decaf377-ka/Cargo.toml
@@ -8,14 +8,15 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
-default = ["std"]
+default = ["std", "rand", "decaf377/arkworks"]
 std = ["ark-ff/std"]
+rand = ["decaf377/rand", "rand_core"]
 
 [dependencies]
 ark-ff = {workspace = true, default-features = false}
 decaf377 = {workspace = true}
 hex = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 thiserror = {workspace = true}
 zeroize = "1.4"
 zeroize_derive = "1.3"

--- a/crates/crypto/decaf377-ka/src/lib.rs
+++ b/crates/crypto/decaf377-ka/src/lib.rs
@@ -5,6 +5,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use decaf377::{self};
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
@@ -39,6 +40,7 @@ pub enum Error {
 
 impl Secret {
     /// Generate a new secret key using `rng`.
+    #[cfg(feature = "rand")]
     pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         Self(decaf377::Fr::rand(rng))
     }

--- a/crates/crypto/proof-params/Cargo.toml
+++ b/crates/crypto/proof-params/Cargo.toml
@@ -23,7 +23,7 @@ hex = { version = "0.4.3", optional = true }
 anyhow = "1"
 
 [features]
-default = []
+default = ["rand", "decaf377/arkworks"]
 bundled-proving-keys = []
 download-proving-keys = [
     "regex",
@@ -40,6 +40,11 @@ parallel = [
     "ark-std/parallel",
     "ark-r1cs-std/parallel",
 ]
+rand = [
+    "rand_core",
+    "dep:rand",
+    "decaf377/rand",
+]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -52,11 +57,11 @@ ark-serialize = {workspace = true}
 ark-snark = {workspace = true}
 ark-std = {workspace = true, default-features = false}
 bech32 = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
-rand = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true, optional = true}
+rand_core = {workspace = true, features = ["getrandom"], optional = true}
 serde = {workspace = true, features = ["derive"]}
 sha2 = {workspace = true}
 tracing = {workspace = true}

--- a/crates/crypto/proof-params/src/lib.rs
+++ b/crates/crypto/proof-params/src/lib.rs
@@ -15,10 +15,10 @@ pub const GROTH16_PROOF_LENGTH_BYTES: usize = 192;
 
 mod traits;
 
-pub use traits::{
-    generate_constraint_matrices, generate_prepared_test_parameters, generate_test_parameters,
-    DummyWitness, ProvingKeyExt, VerifyingKeyExt,
-};
+pub use traits::{generate_constraint_matrices, DummyWitness, ProvingKeyExt, VerifyingKeyExt};
+
+#[cfg(feature = "rand")]
+pub use traits::{generate_prepared_test_parameters, generate_test_parameters};
 
 /// A wrapper around a proving key that can be lazily loaded.
 ///

--- a/crates/crypto/proof-params/src/traits.rs
+++ b/crates/crypto/proof-params/src/traits.rs
@@ -1,11 +1,13 @@
 use ark_ec::pairing::Pairing;
-use ark_groth16::{
-    r1cs_to_qap::LibsnarkReduction, Groth16, PreparedVerifyingKey, ProvingKey, VerifyingKey,
-};
+#[cfg(feature = "rand")]
+use ark_groth16::{r1cs_to_qap::LibsnarkReduction, Groth16};
+use ark_groth16::{PreparedVerifyingKey, ProvingKey, VerifyingKey};
 use ark_relations::r1cs::{self, ConstraintMatrices, ConstraintSynthesizer};
 use ark_serialize::CanonicalSerialize;
+#[cfg(feature = "rand")]
 use ark_snark::SNARK;
 use decaf377::Bls12_377;
+#[cfg(feature = "rand")]
 use rand_core::CryptoRngCore;
 
 /// This trait characterizes circuits which can generate constraints.
@@ -46,6 +48,7 @@ pub fn generate_constraint_matrices<T: DummyWitness>(
 ///
 /// These parameters should not be used for actual production code,
 /// because the randomness may not have been securely destroyed.
+#[cfg(feature = "rand")]
 pub fn generate_test_parameters<T: DummyWitness>(
     rng: &mut impl CryptoRngCore,
 ) -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
@@ -60,6 +63,7 @@ pub fn generate_test_parameters<T: DummyWitness>(
 
 /// A variant of `generate_test_parameters` which spits out a verifying key with some
 /// precomputation.
+#[cfg(feature = "rand")]
 pub fn generate_prepared_test_parameters<T: DummyWitness>(
     rng: &mut impl CryptoRngCore,
 ) -> (ProvingKey<Bls12_377>, PreparedVerifyingKey<Bls12_377>) {

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -8,10 +8,15 @@ license = {workspace = true}
 edition = {workspace = true}
 
 [features]
+default = ["rand", "decaf377/arkworks"]
 internal = []
 arbitrary = ["proptest", "proptest-derive"]
 r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs", "poseidon377/r1cs"]
 parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel", "poseidon377/parallel"]
+rand = [
+    "dep:rand",
+    "decaf377/rand",
+]
 
 [dependencies]
 ark-ed-on-bls12-377 = "0.4"
@@ -21,7 +26,7 @@ ark-relations = {workspace = true, optional = true}
 ark-serialize = {workspace = true}
 async-trait = {workspace = true}
 blake2b_simd = {workspace = true}
-decaf377 = {workspace = true, default-features = true}
+decaf377 = {workspace = true}
 derivative = {workspace = true}
 futures = {workspace = true}
 getrandom = {workspace = true, features = ["js"]}
@@ -30,11 +35,11 @@ hex = {workspace = true}
 im = {workspace = true, features = ["serde"]}
 once_cell = {workspace = true}
 parking_lot = {workspace = true}
-penumbra-sdk-proto = {workspace = true, default-features = true}
+penumbra-sdk-proto = {workspace = true}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 proptest = {workspace = true, optional = true}
 proptest-derive = {workspace = true, optional = true}
-rand = {workspace = true}
+rand = {workspace = true, optional = true}
 serde = {workspace = true, features = ["derive", "rc"]}
 thiserror = {workspace = true}
 tracing = {workspace = true}

--- a/crates/crypto/tct/src/lib.rs
+++ b/crates/crypto/tct/src/lib.rs
@@ -55,6 +55,7 @@ extern crate async_trait;
 mod commitment;
 mod index;
 mod proof;
+#[cfg(feature = "rand")]
 mod random;
 mod tree;
 mod witness;

--- a/crates/crypto/tct/src/lib.rs
+++ b/crates/crypto/tct/src/lib.rs
@@ -68,6 +68,7 @@ pub mod validate;
 pub use {
     commitment::StateCommitment,
     internal::hash::Forgotten,
+    internal::hash::Hash,
     internal::hash::DOMAIN_SEPARATOR,
     proof::Proof,
     tree::{Position, Root, Tree},

--- a/crates/crypto/tct/src/proof.rs
+++ b/crates/crypto/tct/src/proof.rs
@@ -1,5 +1,3 @@
-use poseidon377::Fq;
-
 use crate::prelude::*;
 
 /// A proof of the inclusion of some [`Commitment`] in a [`Tree`] with a particular [`Root`].
@@ -56,9 +54,10 @@ impl Proof {
     }
 
     /// Generate a dummy [`Proof`] for a given commitment.
+    #[cfg(feature = "rand")]
     pub fn dummy<R: Rng + rand::CryptoRng>(rng: &mut R, commitment: StateCommitment) -> Self {
         let dummy_position = 0u64.into();
-        let dummy_auth_path: [[Hash; 3]; 24] = [[Hash::new(Fq::rand(rng)); 3]; 24];
+        let dummy_auth_path: [[Hash; 3]; 24] = [[Hash::new(poseidon377::Fq::rand(rng)); 3]; 24];
         Self::new(commitment, dummy_position, dummy_auth_path)
     }
 
@@ -122,6 +121,7 @@ impl Proof {
 }
 
 use penumbra_sdk_proto::penumbra::crypto::tct::v1 as pb;
+#[cfg(feature = "rand")]
 use rand::Rng;
 
 impl From<Proof> for pb::StateCommitmentProof {

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -21,6 +21,7 @@ tendermint = [
     "dep:thiserror",
     "dep:tonic",
 ]
+ibc = ["dep:ibc-types", "dep:thiserror"]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -29,13 +30,13 @@ bech32 = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 chrono = {workspace = true, optional = true, default-features = false, features = ["serde"]}
 cnidarium = {workspace = true, optional = true, default-features = true, features = ["rpc"]}
-decaf377-fmd = {workspace = true}
-decaf377-rdsa = {workspace = true}
+decaf377-fmd = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true, default-features = false, features = ["serde"]}
 futures = {workspace = true}
 hex = {workspace = true}
 http-body = {workspace = true, optional = true}
 http-body-util = {workspace = true, optional = true}
-ibc-types = {workspace = true, features = ["std"], default-features = true}
+ibc-types = {workspace = true, optional = true, features = ["std"], default-features = true}
 ics23 = {workspace = true}
 pbjson = {workspace = true}
 pbjson-types = {workspace = true}

--- a/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.rs
+++ b/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.rs
@@ -70,6 +70,43 @@ impl ::prost::Name for DkgRound2Package {
         "/penumbra.crypto.decaf377_frost.v1.DKGRound2Package".into()
     }
 }
+/// A signing nonce, a scalar used once in the signing protocol.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Nonce {
+    /// These bytes should be a valid scalar.
+    #[prost(bytes = "vec", tag = "1")]
+    pub scalar: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for Nonce {
+    const NAME: &'static str = "Nonce";
+    const PACKAGE: &'static str = "penumbra.crypto.decaf377_frost.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "penumbra.crypto.decaf377_frost.v1.Nonce".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/penumbra.crypto.decaf377_frost.v1.Nonce".into()
+    }
+}
+/// The nonces used for a single FROST signing ceremony.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SigningNonces {
+    /// The hiding nonce.
+    #[prost(message, optional, tag = "1")]
+    pub hiding: ::core::option::Option<Nonce>,
+    /// The binding nonce.
+    #[prost(message, optional, tag = "2")]
+    pub binding: ::core::option::Option<Nonce>,
+}
+impl ::prost::Name for SigningNonces {
+    const NAME: &'static str = "SigningNonces";
+    const PACKAGE: &'static str = "penumbra.crypto.decaf377_frost.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "penumbra.crypto.decaf377_frost.v1.SigningNonces".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/penumbra.crypto.decaf377_frost.v1.SigningNonces".into()
+    }
+}
 /// Represents a commitment to a nonce value.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NonceCommitment {

--- a/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.serde.rs
+++ b/crates/proto/src/gen/penumbra.crypto.decaf377_frost.v1.serde.rs
@@ -211,6 +211,105 @@ impl<'de> serde::Deserialize<'de> for DkgRound2Package {
         deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.DKGRound2Package", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for Nonce {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.scalar.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.crypto.decaf377_frost.v1.Nonce", len)?;
+        if !self.scalar.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("scalar", pbjson::private::base64::encode(&self.scalar).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Nonce {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "scalar",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Scalar,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "scalar" => Ok(GeneratedField::Scalar),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Nonce;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.crypto.decaf377_frost.v1.Nonce")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Nonce, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut scalar__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Scalar => {
+                            if scalar__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("scalar"));
+                            }
+                            scalar__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(Nonce {
+                    scalar: scalar__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.Nonce", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for NonceCommitment {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -519,6 +618,118 @@ impl<'de> serde::Deserialize<'de> for SigningCommitments {
             }
         }
         deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.SigningCommitments", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SigningNonces {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.hiding.is_some() {
+            len += 1;
+        }
+        if self.binding.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.crypto.decaf377_frost.v1.SigningNonces", len)?;
+        if let Some(v) = self.hiding.as_ref() {
+            struct_ser.serialize_field("hiding", v)?;
+        }
+        if let Some(v) = self.binding.as_ref() {
+            struct_ser.serialize_field("binding", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SigningNonces {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "hiding",
+            "binding",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Hiding,
+            Binding,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "hiding" => Ok(GeneratedField::Hiding),
+                            "binding" => Ok(GeneratedField::Binding),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SigningNonces;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.crypto.decaf377_frost.v1.SigningNonces")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SigningNonces, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut hiding__ = None;
+                let mut binding__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Hiding => {
+                            if hiding__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hiding"));
+                            }
+                            hiding__ = map_.next_value()?;
+                        }
+                        GeneratedField::Binding => {
+                            if binding__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("binding"));
+                            }
+                            binding__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(SigningNonces {
+                    hiding: hiding__,
+                    binding: binding__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.crypto.decaf377_frost.v1.SigningNonces", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SigningShare {

--- a/crates/proto/src/protobuf.rs
+++ b/crates/proto/src/protobuf.rs
@@ -1,3 +1,5 @@
+// Required for `type_url()` method resolution on generic associated types
+#[allow(unused_imports)]
 use crate::Name;
 use std::convert::{From, TryFrom};
 
@@ -40,6 +42,7 @@ where
 // This should only be done here in cases where the domain type lives in a crate
 // that shouldn't depend on the Penumbra proto framework.
 
+#[cfg(feature = "ibc")]
 use crate::penumbra::core::component::ibc::v1::IbcRelay;
 use crate::penumbra::crypto::decaf377_rdsa::v1::{
     BindingSignature, SpendAuthSignature, SpendVerificationKey,
@@ -131,12 +134,15 @@ impl TryFrom<ProtoClue> for Clue {
 // The tendermint-rs PublicKey type already has a tendermint-proto type;
 // this redefines its proto, because the encodings are consensus-critical
 // and we don't vendor all of the tendermint protos.
+#[cfg(feature = "tendermint")]
 use crate::penumbra::core::keys::v1::ConsensusKey;
 
+#[cfg(feature = "tendermint")]
 impl DomainType for tendermint::PublicKey {
     type Proto = ConsensusKey;
 }
 
+#[cfg(feature = "tendermint")]
 impl From<tendermint::PublicKey> for crate::penumbra::core::keys::v1::ConsensusKey {
     fn from(v: tendermint::PublicKey) -> Self {
         Self {
@@ -145,6 +151,7 @@ impl From<tendermint::PublicKey> for crate::penumbra::core::keys::v1::ConsensusK
     }
 }
 
+#[cfg(feature = "tendermint")]
 impl TryFrom<crate::core::keys::v1::ConsensusKey> for tendermint::PublicKey {
     type Error = anyhow::Error;
     fn try_from(value: crate::core::keys::v1::ConsensusKey) -> Result<Self, Self::Error> {
@@ -154,41 +161,60 @@ impl TryFrom<crate::core::keys::v1::ConsensusKey> for tendermint::PublicKey {
 }
 
 // IBC-rs impls
+#[cfg(feature = "ibc")]
 extern crate ibc_types;
 
+#[cfg(feature = "ibc")]
 use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
+#[cfg(feature = "ibc")]
 use ibc_proto::ibc::core::client::v1::Height as RawHeight;
+#[cfg(feature = "ibc")]
 use ibc_proto::ibc::core::connection::v1::ClientPaths as RawClientPaths;
+#[cfg(feature = "ibc")]
 use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
 
+#[cfg(feature = "ibc")]
 use ibc_types::core::channel::ChannelEnd;
+#[cfg(feature = "ibc")]
 use ibc_types::core::client::Height;
+#[cfg(feature = "ibc")]
 use ibc_types::core::connection::{ClientPaths, ConnectionEnd};
+#[cfg(feature = "ibc")]
 use ibc_types::lightclients::tendermint::client_state::ClientState;
+#[cfg(feature = "ibc")]
 use ibc_types::lightclients::tendermint::consensus_state::ConsensusState;
 
+#[cfg(feature = "ibc")]
 impl DomainType for ClientPaths {
     type Proto = RawClientPaths;
 }
 
+#[cfg(feature = "ibc")]
 impl DomainType for ConnectionEnd {
     type Proto = RawConnectionEnd;
 }
 
+#[cfg(feature = "ibc")]
 impl DomainType for ChannelEnd {
     type Proto = RawChannel;
 }
+
+#[cfg(feature = "ibc")]
 impl DomainType for Height {
     type Proto = RawHeight;
 }
 
+#[cfg(feature = "ibc")]
 impl DomainType for ClientState {
     type Proto = ibc_proto::google::protobuf::Any;
 }
+
+#[cfg(feature = "ibc")]
 impl DomainType for ConsensusState {
     type Proto = ibc_proto::google::protobuf::Any;
 }
 
+#[cfg(feature = "ibc")]
 impl<T> From<T> for IbcRelay
 where
     T: ibc_types::DomainType + Send + Sync + 'static,

--- a/crates/proto/src/serializers/bech32str.rs
+++ b/crates/proto/src/serializers/bech32str.rs
@@ -77,7 +77,7 @@ pub mod validator_identity_key {
     use super::*;
 
     /// The Bech32 prefix used for validator identity keys.
-    pub const BECH32_PREFIX: &str = "penumbravalid";
+    pub const BECH32_PREFIX: &str = "cyclesvalid";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -99,7 +99,7 @@ pub mod validator_governance_key {
     use super::*;
 
     /// The Bech32 prefix used for validator governance keys.
-    pub const BECH32_PREFIX: &str = "penumbragovern";
+    pub const BECH32_PREFIX: &str = "cyclesgovern";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -121,7 +121,7 @@ pub mod address {
     use super::*;
 
     /// The Bech32 prefix used for addresses.
-    pub const BECH32_PREFIX: &str = "penumbra";
+    pub const BECH32_PREFIX: &str = "cycles";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -143,7 +143,7 @@ pub mod compat_address {
     use super::*;
 
     /// The Bech32 prefix used for compat addresses (Bech32, not Bech32m, addresses).
-    pub const BECH32_PREFIX: &str = "penumbracompat1";
+    pub const BECH32_PREFIX: &str = "cyclescompat1";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -187,7 +187,7 @@ pub mod full_viewing_key {
     use super::*;
 
     /// The Bech32 prefix used for full viewing keys.
-    pub const BECH32_PREFIX: &str = "penumbrafullviewingkey";
+    pub const BECH32_PREFIX: &str = "cyclesfullviewingkey";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -209,7 +209,7 @@ pub mod wallet_id {
     use super::*;
 
     /// The Bech32 prefix used for wallet ids.
-    pub const BECH32_PREFIX: &str = "penumbrawalletid";
+    pub const BECH32_PREFIX: &str = "cycleswalletid";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
@@ -231,7 +231,7 @@ pub mod spend_key {
     use super::*;
 
     /// The Bech32 prefix used for spend keys.
-    pub const BECH32_PREFIX: &str = "penumbraspendkey";
+    pub const BECH32_PREFIX: &str = "cyclesspendkey";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where

--- a/crates/view/src/note_record.rs
+++ b/crates/view/src/note_record.rs
@@ -108,7 +108,7 @@ impl TryFrom<&Row<'_>> for SpendableNoteRecord {
                     amount: u128::from_be_bytes(row.get::<_, [u8; 16]>("amount")?).into(),
                     asset_id: row.get::<_, Vec<u8>>("asset_id")?[..].try_into()?,
                 },
-                Rseed(row.get::<_, [u8; 32]>("rseed")?),
+                Rseed::from(row.get::<_, [u8; 32]>("rseed")?),
             )?,
             source: CommitmentSource::decode(&row.get::<_, Vec<u8>>("source")?[..])?,
             return_address,

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -1346,7 +1346,7 @@ impl Storage {
                     let amount = row.get::<_, [u8; 16]>("amount")?;
                     let amount_u128: u128 = u128::from_be_bytes(amount);
                     let asset_id = asset::Id(Fq::from_bytes_checked(&row.get::<_, [u8; 32]>("asset_id")?).expect("asset id malformed"));
-                    let rseed = Rseed(row.get::<_, [u8; 32]>("rseed")?);
+                    let rseed = Rseed::from(row.get::<_, [u8; 32]>("rseed")?);
                     let note = Note::from_parts(
                         address,
                         Value {

--- a/deployments/scripts/check-crate-feature-sets
+++ b/deployments/scripts/check-crate-feature-sets
@@ -2,6 +2,8 @@
 # CI script to verify that each crate in the monorepo builds independently.
 # This helps us ensure that the feature-gating for e.g. "component" is
 # declared explicitly.
+#
+# For Cycles fork: only check crates that Cycles depends on (not full workspace)
 set -euo pipefail
 
 
@@ -10,4 +12,23 @@ if ! hash cargo-hack >/dev/null 2>&1 ; then
     exit 1
 fi
 
-cargo hack check --workspace --all-targets --all-features --release
+# Crates that Cycles protocol depends on
+packages=(
+    decaf377-fmd
+    decaf377-ka
+    penumbra-sdk-asset
+    penumbra-sdk-keys
+    penumbra-sdk-num
+    penumbra-sdk-proof-params
+    penumbra-sdk-proto
+    penumbra-sdk-sct
+    penumbra-sdk-shielded-pool
+    penumbra-sdk-tct
+)
+
+pkg_flags=""
+for p in "${packages[@]}"; do
+    pkg_flags="$pkg_flags -p $p"
+done
+
+cargo hack check $pkg_flags --all-targets --all-features --release

--- a/deployments/scripts/check-wasm-compat.sh
+++ b/deployments/scripts/check-wasm-compat.sh
@@ -16,24 +16,25 @@ set -euo pipefail
 #
 # to make sure at least all of those crates are tracked here.
 
+# For Cycles fork: only check crates we directly depend on.
 packages=(
     penumbra-sdk-asset
-    penumbra-sdk-community-pool
-    penumbra-sdk-compact-block
-    penumbra-sdk-auction
-    penumbra-sdk-dex
-    penumbra-sdk-distributions
+#    penumbra-sdk-community-pool
+#    penumbra-sdk-compact-block
+#    penumbra-sdk-auction
+#    penumbra-sdk-dex
+#    penumbra-sdk-distributions
     penumbra-sdk-fee
-    penumbra-sdk-funding
-    penumbra-sdk-governance
-    penumbra-sdk-ibc
+#    penumbra-sdk-funding
+#    penumbra-sdk-governance
+#    penumbra-sdk-ibc
     penumbra-sdk-keys
     penumbra-sdk-sct
     penumbra-sdk-shielded-pool
-    penumbra-sdk-stake
+#    penumbra-sdk-stake
     penumbra-sdk-tct
-    penumbra-sdk-transaction
-    penumbra-sdk-txhash
+#    penumbra-sdk-transaction
+#    penumbra-sdk-txhash
     # N.B. we can't include those ones because they rely on `getrandom`,
     # but there's a `js` feature...
     # decaf377-fmd

--- a/justfile
+++ b/justfile
@@ -21,9 +21,13 @@ build:
     cargo build --release --all-features --all-targets
 
 # Runs 'cargo check' on all rust files in the project.
+# For Cycles fork: exclude binary crates (require LFS) and custody chain (FROST threshold signing not used)
 check:
   # check, failing on warnings
-  RUSTFLAGS="-D warnings" cargo check --release --all-targets --all-features --target-dir=target/check
+  RUSTFLAGS="-D warnings" cargo check --release --all-targets --all-features --target-dir=target/check \
+    --workspace --exclude pd --exclude pcli --exclude pclientd --exclude pmonitor --exclude pindexer \
+    --exclude elcuity --exclude penumbra-sdk-custody --exclude penumbra-sdk-custody-ledger-usb \
+    --exclude penumbra-sdk-wallet --exclude penumbra-sdk-app-tests
   # fmt dry-run, failing on any suggestions
   cargo fmt --all -- --check
 
@@ -47,8 +51,12 @@ rustdocs:
     ./deployments/scripts/rust-docs
 
 # Run rust unit tests, via cargo-nextest
+# For Cycles fork: exclude binary crates (require LFS) and custody chain (FROST threshold signing not used)
 test:
-  cargo nextest run --release
+  cargo nextest run --release --workspace \
+    --exclude pd --exclude pcli --exclude pclientd --exclude pmonitor --exclude pindexer \
+    --exclude elcuity --exclude penumbra-sdk-custody --exclude penumbra-sdk-custody-ledger-usb \
+    --exclude penumbra-sdk-wallet --exclude penumbra-sdk-app-tests
 
 # Run integration tests against the testnet, for validating HTTPS support
 integration-testnet:

--- a/proto/penumbra/penumbra/crypto/decaf377_frost/v1/decaf377_frost.proto
+++ b/proto/penumbra/penumbra/crypto/decaf377_frost/v1/decaf377_frost.proto
@@ -28,6 +28,20 @@ message DKGRound2Package {
   SigningShare signing_share = 1;
 }
 
+// A signing nonce, a scalar used once in the signing protocol.
+message Nonce {
+  // These bytes should be a valid scalar.
+  bytes scalar = 1;
+}
+
+// The nonces used for a single FROST signing ceremony.
+message SigningNonces {
+  // The hiding nonce.
+  Nonce hiding = 1;
+  // The binding nonce.
+  Nonce binding = 2;
+}
+
 // Represents a commitment to a nonce value.
 message NonceCommitment {
   // These bytes should be a valid group element.


### PR DESCRIPTION
## Summary

Closes: https://github.com/cycles-money/cycles-protocol/issues/615

Clean history rewrite of `v2.0.4-fork` for audit readiness. Reconstructs all fork changes on top of upstream `v2.0.4` as 6 atomic, logical commits:

1. **deps**: Redirect decaf377, decaf377-rdsa, poseidon377 to Informal Systems forks; pin frost deps
2. **keys**: Rename all Bech32 HRPs from `penumbra` to `cycles`
3. **tct**: Expose `tct::Hash` publicly for Cycles tree operations
4. **shielded-pool**: Change `Rseed` type from `[u8; 32]` to `Fq`; replace PRF-based note blinding with Poseidon hash using Cycles-specific RCM domain separator
5. **feature gates**: Gate `rand`, `r1cs`, `ibc`, `tendermint` behind optional features across crypto/core crates for WASM/CosmWasm compatibility
6. **ci**: Adapt CI, test exclusions, and validator regex for fork

Also adds a [FORK_CHANGES.md](https://github.com/informalsystems/penumbra/blob/v2.0.4-audit/FORK_CHANGES.md) file to aid auditors. 

## Verification

- `git diff v2.0.4-audit v2.0.4-fork` is empty (exact parity)
- `just check` passes
- `just test` passes (296 tests, 4 skipped)